### PR TITLE
Remove ‘exact’ from navlinks

### DIFF
--- a/src/components/side-nav.js
+++ b/src/components/side-nav.js
@@ -119,7 +119,7 @@ export default function SideNav(props) {
               {/* TODO: Toggle HIDDEN attr on click to hide/show nav items within a block */}
               <div className="navBlock">
                 {navBlock.items.map(link => (
-                  <NavLink exact key={link.route} to={link.route} activeClassName="is-active"
+                  <NavLink key={link.route} to={link.route} activeClassName="is-active"
 
                     className={`auro_hyperlink auro_hyperlink--nav ${link.active ? 'auro_hyperlink--active': ''} ${link.subNav ? 'auro_hyperlink--subNav': ''} ${link.parent ? 'auro_hyperlink--parent': ''}`}>
 


### PR DESCRIPTION
'exact' attr preventing active status for left nav links when viewing tabs other than the landing tab

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #14

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**