### PR TITLE
docs: add auro-1 & auro-2 themes to design tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@aurodesignsystem/auro-table": "^4.1.0",
         "@aurodesignsystem/auro-toast": "^3.1.0",
         "@aurodesignsystem/auro-tokenlist": "^1.4.0",
-        "@aurodesignsystem/design-tokens": "5.14.0",
+        "@aurodesignsystem/design-tokens": "5.15.1",
         "@aurodesignsystem/wc-generator": "^4.7.1",
         "@aurodesignsystem/webcorestylesheets": "^6.3.1",
         "@commitlint/cli": "^19.6.0",
@@ -842,6 +842,19 @@
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "*"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-card/node_modules/@aurodesignsystem/design-tokens": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-5.14.0.tgz",
+      "integrity": "sha512-4fhWdUXDAqCkwQbzzSOMvkMRLzQVoekD4EetMrEvVYsPOcVmngJvThxDvWMy8dnqbXG9PUYvK8LQE0ctU243nQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "postcss": "^8.5.3"
+      },
+      "engines": {
+        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@aurodesignsystem/auro-card/node_modules/@aurodesignsystem/webcorestylesheets": {
@@ -2303,11 +2316,10 @@
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-5.14.0.tgz",
-      "integrity": "sha512-4fhWdUXDAqCkwQbzzSOMvkMRLzQVoekD4EetMrEvVYsPOcVmngJvThxDvWMy8dnqbXG9PUYvK8LQE0ctU243nQ==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-5.15.1.tgz",
+      "integrity": "sha512-X+PaOI4llz1jAwbwlH4k2yP9xDm/Q4HtTCdZLKU9NuBuFMmmMVPURCIHjlBZzxy8T7chhhr4t41XXXhIX/KLbA==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",
         "postcss": "^8.5.3"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@aurodesignsystem/auro-table": "^4.1.0",
     "@aurodesignsystem/auro-toast": "^3.1.0",
     "@aurodesignsystem/auro-tokenlist": "^1.4.0",
-    "@aurodesignsystem/design-tokens": "5.14.0",
+    "@aurodesignsystem/design-tokens": "5.15.1",
     "@aurodesignsystem/wc-generator": "^4.7.1",
     "@aurodesignsystem/webcorestylesheets": "^6.3.1",
     "@commitlint/cli": "^19.6.0",

--- a/src/App.js
+++ b/src/App.js
@@ -103,6 +103,8 @@ import AuroClassicTokens from './content/dynamic/designTokens/auro-classic';
 import AlaskaTokens from './content/dynamic/designTokens/alaska';
 import AlaskaClassicTokens from './content/dynamic/designTokens/alaska-classic';
 import HawaiianTokens from './content/dynamic/designTokens/hawaiian';
+import Auro1Tokens from './content/dynamic/designTokens/auro-1';
+import Auro2Tokens from './content/dynamic/designTokens/auro-2';
 import DesignTokensInstall from './content/dynamic/designTokens/install';
 
 // design tokens docs
@@ -550,6 +552,8 @@ function App() {
               <Route path="/getting-started/developers/design-tokens/alaska" element={<AlaskaTokens />} />
               <Route path="/getting-started/developers/design-tokens/alaska-classic" element={<AlaskaClassicTokens />} />
               <Route path="/getting-started/developers/design-tokens/hawaiian" element={<HawaiianTokens />} />
+              <Route path="/getting-started/developers/design-tokens/auro-1" element={<Auro1Tokens />} />
+              <Route path="/getting-started/developers/design-tokens/auro-2" element={<Auro2Tokens />} />
               <Route path="/design-tokens/deprecated" element={<AuroClassicTokens />} />
 
               {/* Design Tokens Docs */}

--- a/src/content/dynamic/designTokens/auro-1.js
+++ b/src/content/dynamic/designTokens/auro-1.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ThemeTokens from './components/ThemeTokens';
+import { auro1Tokens } from './config/token-mapping';
+
+class AlaskaTokens extends Component {
+  render() {
+    const { basicTokensMap, advancedTokensMap } = auro1Tokens;
+    
+    return (
+      <ThemeTokens 
+        theme="a1"
+        themeName="Auro 1"
+        basicTokensMap={basicTokensMap}
+        advancedTokensMap={advancedTokensMap}
+      />
+    );
+  }
+}
+
+export default AlaskaTokens;

--- a/src/content/dynamic/designTokens/auro-2.js
+++ b/src/content/dynamic/designTokens/auro-2.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ThemeTokens from './components/ThemeTokens';
+import { auro2Tokens } from './config/token-mapping';
+
+class AlaskaTokens extends Component {
+  render() {
+    const { basicTokensMap, advancedTokensMap } = auro2Tokens;
+    
+    return (
+      <ThemeTokens 
+        theme="a2"
+        themeName="Auro 2"
+        basicTokensMap={basicTokensMap}
+        advancedTokensMap={advancedTokensMap}
+      />
+    );
+  }
+}
+
+export default AlaskaTokens;

--- a/src/content/dynamic/designTokens/components/AdvancedTokensNotice.js
+++ b/src/content/dynamic/designTokens/components/AdvancedTokensNotice.js
@@ -2,7 +2,7 @@ const AdvancedTokensNotice = () => {
   return (
     <div>
       <p>
-        The Advanced tokens are used within Auro components and should not be used for general development or design.
+        Advanced tokens are used within Auro components and should not be used for general development or design.
       </p>
     </div>
   );

--- a/src/content/dynamic/designTokens/components/BasicTokensNotice.js
+++ b/src/content/dynamic/designTokens/components/BasicTokensNotice.js
@@ -1,0 +1,11 @@
+const BasicTokensNotice = () => {
+  return (
+    <div>
+      <p>
+        Basic tokens are design tokens used for general application development and design.
+      </p>
+    </div>
+  );
+};
+
+export default BasicTokensNotice;

--- a/src/content/dynamic/designTokens/components/Nav.js
+++ b/src/content/dynamic/designTokens/components/Nav.js
@@ -11,6 +11,8 @@ export class Nav extends Component {
         <NavLink role="tab" end className="tab link" to={`/getting-started/developers/design-tokens/alaska`} >Alaska</NavLink>
         <NavLink role="tab" end className="tab link" to={`/getting-started/developers/design-tokens/alaska-classic`} >Alaska Classic</NavLink>
         <NavLink role="tab" end className="tab link" to={`/getting-started/developers/design-tokens/hawaiian`} >Hawaiian</NavLink>
+        <NavLink role="tab" end className="tab link" to={`/getting-started/developers/design-tokens/auro-1`} >Auro 1</NavLink>
+        <NavLink role="tab" end className="tab link" to={`/getting-started/developers/design-tokens/auro-2`} >Auro 2</NavLink>
         <NavLink role="tab" end className="tab link" to={`/getting-started/developers/design-tokens/auro-classic`} >Auro Classic</NavLink>
       </div>
     )

--- a/src/content/dynamic/designTokens/components/ThemeTokens.js
+++ b/src/content/dynamic/designTokens/components/ThemeTokens.js
@@ -2,6 +2,7 @@ import React from "react";
 import ThemePage from './ThemePage';
 import TokenSection from "./TokenSection";
 import AdvancedTokensNotice from "./AdvancedTokensNotice";
+import BasicTokensNotice from "./BasicTokensNotice";
 import VersionChecker from './VersionChecker';
 
 const ThemeTokens = ({ theme, themeName, basicTokensMap, advancedTokensMap, introContent }) => {
@@ -17,10 +18,13 @@ const ThemeTokens = ({ theme, themeName, basicTokensMap, advancedTokensMap, intr
       {/* Display intro content if provided */}
       {introContent && <div className="theme-intro">{introContent}</div>}
 
-      <h2 className="auro_heading auro_heading--600">Colors</h2>
+      <h2 className="auro_heading auro_heading--600">Basic Tokens</h2>
+      <BasicTokensNotice />
+
+      <h3 className="auro_heading auro_heading--600">Colors</h3>
       <TokenSection 
         tokens={basicColorTokens}
-        headingLevel="h3"
+        headingLevel="h4"
         headingClass="auro_heading auro_heading--400"
         tokenListProps={{
           swatchType: "rectangle",
@@ -28,17 +32,17 @@ const ThemeTokens = ({ theme, themeName, basicTokensMap, advancedTokensMap, intr
         }}
       />
 
-      <h2 className="auro_heading auro_heading--600">Typography</h2>
+      <h3 className="auro_heading auro_heading--600">Typography</h3>
       <TokenSection 
         tokens={fontTokens}
-        headingLevel="h3"
+        headingLevel="h4"
         headingClass="auro_heading auro_heading--400"
       />
 
-      <h2 className="auro_heading auro_heading--600">Corner Radius</h2>
+      <h3 className="auro_heading auro_heading--600">Corner Radius</h3>
       <TokenSection 
         tokens={cornerRadiusTokens}
-        headingLevel="h3"
+        headingLevel="h4"
         headingClass="auro_heading auro_heading--400"
       />
 

--- a/src/content/dynamic/designTokens/config/token-mapping.js
+++ b/src/content/dynamic/designTokens/config/token-mapping.js
@@ -1,6 +1,8 @@
 import alaskaAllTokens from '@aurodesignsystem/design-tokens/dist/alaska/JSObject--allTokens.js';
 import alaskaClassicAllTokens from '@aurodesignsystem/design-tokens/dist/alaska-classic/JSObject--allTokens.js';
 import hawaiianAllTokens from '@aurodesignsystem/design-tokens/dist/hawaiian/JSObject--allTokens.js';
+import auro1AllTokens from '@aurodesignsystem/design-tokens/dist/auro-1/JSObject--allTokens.js';
+import auro2AllTokens from '@aurodesignsystem/design-tokens/dist/auro-2/JSObject--allTokens.js';
 
 /**
  * Creates token mappings for a given theme
@@ -66,9 +68,13 @@ const createTokenMappings = (theme) => {
 export const alaskaTokens = createTokenMappings(alaskaAllTokens);
 export const alaskaClassicTokens = createTokenMappings(alaskaClassicAllTokens);
 export const hawaiianTokens = createTokenMappings(hawaiianAllTokens);
+export const auro1Tokens = createTokenMappings(auro1AllTokens);
+export const auro2Tokens = createTokenMappings(auro2AllTokens);
 
 export default {
   alaska: alaskaTokens,
   alaskaClassic: alaskaClassicTokens,
-  hawaiian: hawaiianTokens
+  hawaiian: hawaiianTokens,
+  auro1: auro1Tokens,
+  auro2: auro2Tokens
 };


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Adds Auro 1 & Auro 2 themes to Design Tokens documentation.

![Screenshot 2025-05-14 at 11 35 58 AM](https://github.com/user-attachments/assets/6c71d467-b020-43a1-829f-8af2e5f1e5bf)

![Screenshot 2025-05-14 at 11 36 28 AM](https://github.com/user-attachments/assets/6fc0bd36-d4c7-4963-b598-96aded54eb91)

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add support for Auro 1 and Auro 2 themes in the design tokens documentation by registering new token mappings, updating navigation and routes, introducing a basic tokens notice, restructuring the ThemeTokens layout, and upgrading the design-tokens package.

New Features:
- Introduce Auro 1 and Auro 2 themes for design tokens documentation
- Add BasicTokensNotice component to highlight general-purpose tokens

Enhancements:
- Restructure ThemeTokens component to separate basic and advanced token sections and adjust heading levels
- Register Auro 1 and Auro 2 token mappings and integrate them into navigation and routing
- Refine AdvancedTokensNotice wording to remove unnecessary article

Build:
- Bump @aurodesignsystem/design-tokens dependency to v5.15.1