### PR TITLE
docs: update deprecation language for auro classic theme

### DIFF
--- a/src/content/dynamic/designTokens/auro-classic.js
+++ b/src/content/dynamic/designTokens/auro-classic.js
@@ -74,7 +74,7 @@ class AuroClassicTokens extends Component {
       <ThemePage>
         <h1 className="auro_heading auro_heading--display">Auro Classic Design Tokens</h1>
 
-        <p><span style={warningStyle}>DEPRECATED</span>: The Auro Classic design tokens are provided for backward compatibility of existing content.</p>
+        <p><span style={warningStyle}>DEPRECATED</span>: The <strong>color tokens</strong> from Auro Classic are deprecated and provided solely for backward compatibility with existing content. Other design tokens remain supported.</p>
         <p>Please use v5.x tokens for all new&nbsp;development.</p>
 
         <div className="auro_heading auro_heading--600 version-indicator">v4.x Tokens</div>
@@ -82,6 +82,10 @@ class AuroClassicTokens extends Component {
         <TokenSection tokens={generalTokens} />
 
         <h2 className="auro_heading auro_heading--600">Colors</h2>
+
+        <p><span style={warningStyle}>DEPRECATED</span>: The <strong>color tokens</strong> from Auro Classic are deprecated and provided solely for backward compatibility with existing content.</p>
+        <p>Please use v5.x tokens for all new&nbsp;development.</p>
+
         <TokenSection 
           tokens={colorTokens}
           headingLevel="h3"


### PR DESCRIPTION
# Alaska Airlines Pull Request

Some of the language regarding the Auro Classic theme deprecation was confusing and unclear.

This update improves the wording to be more clear and understandable.

### Updated

![Image](https://github.com/user-attachments/assets/3f29f968-588a-45b1-bddb-a48060638f02)

![Image](https://github.com/user-attachments/assets/61f7f51a-9505-4cf3-afca-1bbb234dc370)

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Clarify deprecation messaging for Auro Classic design tokens to specify that only color tokens are deprecated while other tokens remain supported, and reinforce using v5.x tokens for new development

Documentation:
- Update deprecation notice to emphasize only color tokens are deprecated and provided solely for backward compatibility
- Add duplicated deprecation warning above the Colors section with guidance to use v5.x tokens