### PR TITLE
fix: typography class typo

### DIFF
--- a/src/content/dynamic/typography/usage.js
+++ b/src/content/dynamic/typography/usage.js
@@ -183,7 +183,7 @@ class Typography extends Component {
             Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
           </div>
 
-          <auro-header level="5" display="400">accent-2xx</auro-header>
+          <auro-header level="5" display="400">accent-2xs</auro-header>
 
           <div className="exampleWrapper accent-2xs">
             Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...


### PR DESCRIPTION
# Alaska Airlines Pull Request

On the [Typography documentation](https://auro.alaskaair.com/typography/usage/alaska), `accent-2xx` is not a valid size:

<img width="716" height="148" alt="Image" src="https://github.com/user-attachments/assets/4de5ca83-1bdd-479e-a6cc-80a39dcc2918" />

It should be: `accent-2xs`:

<img width="1076" height="145" alt="Screenshot 2025-09-04 at 1 39 32 PM" src="https://github.com/user-attachments/assets/7ca3042b-7e8a-49ff-b3f3-3f6595b196f3" />

<img width="889" height="132" alt="Screenshot 2025-09-04 at 1 39 47 PM" src="https://github.com/user-attachments/assets/18547919-84f0-4930-9d0b-e5e264b9cdae" />


## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Documentation:
- Update typography usage example to replace invalid accent-2xx with accent-2xs