### PR TITLE
feat: add tail to docsite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@aurodesignsystem/auro-skeleton": "^5.0.0",
         "@aurodesignsystem/auro-slideshow": "^1.2.2",
         "@aurodesignsystem/auro-table": "^5.1.0",
+        "@aurodesignsystem/auro-tail": "^1.0.0",
         "@aurodesignsystem/auro-toast": "^4.0.2",
         "@aurodesignsystem/auro-tokenlist": "^1.5.1",
         "@aurodesignsystem/design-tokens": "8.7.0",
@@ -601,6 +602,18 @@
       },
       "engines": {
         "node": "^20.x || ^22.x "
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-tail": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-tail/-/auro-tail-1.0.0.tgz",
+      "integrity": "sha512-FQgSW82aPOvupyy+AoJ6bCejoWe3rarsyc48Dvzh3ahryZdLIvndZOr4rTuElsxVWuGGB5Y5t8faOqgPFbeqCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lit": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@aurodesignsystem/auro-toast": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@aurodesignsystem/auro-skeleton": "^5.0.0",
     "@aurodesignsystem/auro-slideshow": "^1.2.2",
     "@aurodesignsystem/auro-table": "^5.1.0",
+    "@aurodesignsystem/auro-tail": "^1.0.0",
     "@aurodesignsystem/auro-toast": "^4.0.2",
     "@aurodesignsystem/auro-tokenlist": "^1.5.1",
     "@aurodesignsystem/design-tokens": "8.7.0",

--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,7 @@ import '@aurodesignsystem/auro-tokenlist';
 import '@aurodesignsystem/auro-tokenlist/dist/auro-tokenavatar';
 import '@aurodesignsystem/auro-tokenlist/dist/auro-tokendisplay';
 import '@aurodesignsystem/auro-table';
+import '@aurodesignsystem/auro-tail';
 
 // Logo to appear in console
 import './scripts/auro-consoleLogo';
@@ -433,13 +434,19 @@ import AuroTableApi from './content/dynamic/table/api';
 import AuroTableInstall from './content/dynamic/table/install';
 import AuroTableReleases from './content/dynamic/table/releases';
 
-// toast
+// Tail
+import AuroTail from './content/dynamic/tail/component';
+import AuroTailApi from './content/dynamic/tail/api';
+import AuroTailInstall from './content/dynamic/tail/install';
+import AuroTailReleases from './content/dynamic/tail/releases';
+
+// Toast
 import AuroToast from './content/dynamic/toast/component';
 import AuroToastApi from './content/dynamic/toast/api';
 import AuroToastInstall from './content/dynamic/toast/install';
 import AuroToastReleases from './content/dynamic/toast/releases';
 
-// formkit
+// Formkit
 import AuroFormkitInstall from './content/dynamic/formkit/install';
 import AuroFormkitRelease from './content/dynamic/formkit/releases';
 
@@ -840,6 +847,11 @@ function App() {
               <Route path="/components/auro/table/api" element={<AuroTableApi />} />
               <Route path="/components/auro/table/releases" element={<AuroTableReleases />} />
 
+              {/* Auro Tail */}
+              <Route path="/components/auro/tail" element={<AuroTail />} />
+              <Route path="/components/auro/tail/install" element={<AuroTailInstall />} />
+              <Route path="/components/auro/tail/api" element={<AuroTailApi />} />
+              <Route path="/components/auro/tail/releases" element={<AuroTailReleases />} />
               {/* Auro Toast */}
               <Route path="/components/auro/toast" element={<AuroToast />} />
               <Route path="/components/auro/toast/install" element={<AuroToastInstall />} />

--- a/src/components/side-nav.js
+++ b/src/components/side-nav.js
@@ -79,6 +79,7 @@ export default function SideNav(props) {
         { linkTitle: "Skeleton", route: '/components/auro/skeleton', parent: true },
         { linkTitle: "Slideshow", route: '/components/auro/slideshow', parent: true },
         { linkTitle: "Table", route: '/components/auro/table', parent: true },
+        { linkTitle: "Tail", route: '/components/auro/tail', parent: true },
         { linkTitle: "Toast", route: '/components/auro/toast', parent: true },
       ]
     },

--- a/src/content/dynamic/tail/api.js
+++ b/src/content/dynamic/tail/api.js
@@ -1,0 +1,14 @@
+import AuroComponentContent from "~/functions/renderComponentPage";
+import content from '@aurodesignsystem/auro-tail/demo/api.md';
+
+class AuroContent extends AuroComponentContent {
+
+  constructor(props) {
+    super(props);
+
+    this.markdownContent = content;
+    this.hasCustomElementRegistration = false;
+  };
+}
+
+export default AuroContent;

--- a/src/content/dynamic/tail/component.js
+++ b/src/content/dynamic/tail/component.js
@@ -1,0 +1,15 @@
+import AuroComponentContent from "~/functions/renderComponentPage";
+import '@aurodesignsystem/auro-tail/demo/index.js';
+import content from '@aurodesignsystem/auro-tail/demo/index.md';
+
+class AuroContent extends AuroComponentContent {
+
+  constructor(props) {
+    super(props);
+
+    this.markdownContent = content; 
+    this.hasCustomElementRegistration = false;
+  };
+}
+
+export default AuroContent;

--- a/src/content/dynamic/tail/install.js
+++ b/src/content/dynamic/tail/install.js
@@ -1,0 +1,14 @@
+import AuroComponentContent from "~/functions/renderComponentPage";
+import content from '@aurodesignsystem/auro-tail/readme.md';
+
+class AuroContent extends AuroComponentContent {
+
+  constructor(props) {
+    super(props);
+
+    this.markdownContent = content; 
+    this.hasCustomElementRegistration = false;
+  };
+}
+
+export default AuroContent;

--- a/src/content/dynamic/tail/releases.js
+++ b/src/content/dynamic/tail/releases.js
@@ -1,0 +1,11 @@
+import AuroComponentContent from "~/functions/renderComponentPage";
+
+class AuroContent extends AuroComponentContent {
+  constructor(props) {
+    super(props);
+
+    this.hasCustomElementRegistration = false;
+  };
+}
+
+export default AuroContent;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adds `auro-tail` to the DocSite:

https://github.com/AlaskaAirlines/auro-tail

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add the auro-tail component to the DocSite navigation, routing, and content pages.

New Features:
- Expose the auro-tail component documentation, API, install, and releases pages within the DocSite.

Enhancements:
- Include the @aurodesignsystem/auro-tail package as a project dependency and surface it in the component side navigation.