### PR TITLE
fix(header): harden GCS search input customizations and split Header into focused components

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,9 +81,6 @@
     <link rel="stylesheet" href="/styles/bundled/type/classes.alaska.css">
   </head>
   <body>
-    <script async src="https://cse.google.com/cse.js?cx=b792c366f1ce73e3d"></script>
-    <div class="gcse-search"></div>
-
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,6 @@
       "integrity": "sha512-aS5z3uY5yJirJlja/7MiIXxFnhLLl6dIX5NmAKnpQy95VqAKbyhpvx4zv1mtMJb+y5tQ5qoo46T0SA+oAAR3Sg==",
       "deprecated": "This version is no longer supported. Please update to @aurodesignsystem/design-tokens v4.x for continued support.",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0"
       },
@@ -461,7 +460,6 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-icon/-/auro-icon-9.2.0.tgz",
       "integrity": "sha512-slO+nYQWctYwWWjqBJ2vgOXUSOyGybVHv7P6vV4fVJrdN1WKnwdCUmC1ifoirha0R7z07IDs2d/Lvx3m74CPDw==",
-      "peer": true,
       "dependencies": {
         "lit": "^3.3.2"
       },
@@ -727,7 +725,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1346,7 +1343,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
       "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -2172,7 +2168,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
       "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
         "@babel/helper-module-imports": "^7.29.7",
@@ -4546,6 +4541,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5971,7 +5967,6 @@
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -6119,7 +6114,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -6171,7 +6165,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -6512,8 +6505,7 @@
     "node_modules/@webcomponents/webcomponentsjs": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.8.0.tgz",
-      "integrity": "sha512-loGD63sacRzOzSJgQnB9ZAhaQGkN7wl2Zuw7tsphI5Isa0irijrRo6EnJii/GgjGefIFO8AIO7UivzRhFaEk9w==",
-      "peer": true
+      "integrity": "sha512-loGD63sacRzOzSJgQnB9ZAhaQGkN7wl2Zuw7tsphI5Isa0irijrRo6EnJii/GgjGefIFO8AIO7UivzRhFaEk9w=="
     },
     "node_modules/@wry/caches": {
       "version": "1.0.1",
@@ -6599,7 +6591,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6689,7 +6680,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7159,7 +7149,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7621,7 +7610,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8520,7 +8508,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8899,7 +8886,8 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -9776,7 +9764,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10812,7 +10799,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10996,8 +10982,7 @@
     "node_modules/focus-visible": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.1.tgz",
-      "integrity": "sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA==",
-      "peer": true
+      "integrity": "sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA=="
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -11074,7 +11059,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11616,7 +11600,6 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -13221,7 +13204,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -17120,7 +17102,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -18213,7 +18194,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18605,7 +18585,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -18835,7 +18814,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -18962,7 +18940,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20031,7 +20008,6 @@
       "version": "1.100.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
       "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
-      "peer": true,
       "dependencies": {
         "chokidar": "^5.0.0",
         "immutable": "^5.1.5",
@@ -21279,7 +21255,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -21334,6 +21309,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {
@@ -21669,7 +21660,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21874,7 +21864,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -22512,7 +22501,6 @@
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -22729,7 +22717,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -22895,7 +22882,6 @@
       "version": "5.107.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
       "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -22963,7 +22949,6 @@
       "version": "4.15.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -23449,7 +23434,6 @@
       "version": "2.80.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/src/components/header/SiteSearch.js
+++ b/src/components/header/SiteSearch.js
@@ -1,16 +1,20 @@
-import React, { Component } from 'react';
-import { swapSearchButtonIcon } from './searchIconSwap';
+import React, { useEffect, useRef } from 'react';
+import { HOST_ID, swapSearchButtonIcon } from './searchIconSwap';
 
-const HOST_ID = 'gcse-search-host';
 const GCSE_SCRIPT_SRC = 'https://cse.google.com/cse.js?cx=b792c366f1ce73e3d';
 
-class SiteSearch extends Component {
-  componentDidMount() {
+function SiteSearch() {
+  const hostRef = useRef(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return undefined;
+
     // Load Google Custom Search on demand and explicitly render the widget
     // into our React-mounted host div. `parsetags: 'explicit'` keeps GCS from
     // auto-scanning the page — we own the timing instead.
     const renderGcseSearch = () => {
-      if (window.google && window.google.search && window.google.search.cse) {
+      if (window.google?.search?.cse) {
         try {
           window.google.search.cse.element.render({
             div: HOST_ID,
@@ -27,54 +31,53 @@ class SiteSearch extends Component {
       callback: renderGcseSearch,
     };
 
-    // Avoid injecting a duplicate GCSE script on remount/HMR — the callback
-    // only fires on the initial load, so render directly if it's already there.
+    // Avoid injecting a duplicate GCSE script on remount/HMR. Three cases:
+    //   1) No script yet → inject; the callback above fires on load.
+    //   2) Script present and API ready → render directly.
+    //   3) Script present but API not yet ready (still loading) → do nothing;
+    //      the callback we just installed will fire when load finishes.
     const existingScript = document.querySelector(`script[src="${GCSE_SCRIPT_SRC}"]`);
-    if (existingScript) {
-      renderGcseSearch();
-    } else {
+    if (!existingScript) {
       const gcseScript = document.createElement('script');
       gcseScript.async = true;
       gcseScript.src = GCSE_SCRIPT_SRC;
       document.head.appendChild(gcseScript);
+    } else if (window.google?.search?.cse) {
+      renderGcseSearch();
     }
 
-    // GCS re-renders #gsc-i-id1 on focus/blur/results, wiping any placeholder
-    // we set. Re-apply via MutationObserver so it sticks. The icon swap also
-    // re-runs on every tick so the auro-icon survives GCS re-renders.
+    // GCS re-renders its input/button subtree on focus/blur/results, wiping
+    // any customizations we apply. Re-apply on every relevant DOM change.
     const applySearchCustomizations = () => {
-      const searchInput = document.querySelector('#gsc-i-id1');
+      const searchInput = host.querySelector('#gsc-i-id1');
       if (searchInput && searchInput.getAttribute('placeholder') !== 'Search') {
         searchInput.setAttribute('placeholder', 'Search');
       }
-
       swapSearchButtonIcon();
     };
 
     applySearchCustomizations();
 
-    const searchContainer = document.getElementById(HOST_ID);
-    if (searchContainer && typeof MutationObserver !== 'undefined') {
-      this.searchObserver = new MutationObserver(applySearchCustomizations);
-      this.searchObserver.observe(searchContainer, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['placeholder'],
-      });
+    let observer;
+    if (typeof MutationObserver !== 'undefined') {
+      observer = new MutationObserver(applySearchCustomizations);
+      // childList + subtree is enough: GCS replaces nodes wholesale on each
+      // re-render, so we don't need to watch individual attributes (which
+      // would also create a feedback loop with our own setAttribute calls).
+      observer.observe(host, { childList: true, subtree: true });
     }
-  }
 
-  componentWillUnmount() {
-    if (this.searchObserver) {
-      this.searchObserver.disconnect();
-      this.searchObserver = null;
-    }
-  }
+    return () => {
+      if (observer) observer.disconnect();
+      // Drop the global only if it still points at this mount's closure, so
+      // a remount that already installed a fresh callback isn't clobbered.
+      if (window.__gcse && window.__gcse.callback === renderGcseSearch) {
+        delete window.__gcse;
+      }
+    };
+  }, []);
 
-  render() {
-    return <div id={HOST_ID} />;
-  }
+  return <div ref={hostRef} id={HOST_ID} />;
 }
 
 export default SiteSearch;

--- a/src/components/header/SiteSearch.js
+++ b/src/components/header/SiteSearch.js
@@ -27,10 +27,17 @@ class SiteSearch extends Component {
       callback: renderGcseSearch,
     };
 
-    const gcseScript = document.createElement('script');
-    gcseScript.async = true;
-    gcseScript.src = GCSE_SCRIPT_SRC;
-    document.head.appendChild(gcseScript);
+    // Avoid injecting a duplicate GCSE script on remount/HMR — the callback
+    // only fires on the initial load, so render directly if it's already there.
+    const existingScript = document.querySelector(`script[src="${GCSE_SCRIPT_SRC}"]`);
+    if (existingScript) {
+      renderGcseSearch();
+    } else {
+      const gcseScript = document.createElement('script');
+      gcseScript.async = true;
+      gcseScript.src = GCSE_SCRIPT_SRC;
+      document.head.appendChild(gcseScript);
+    }
 
     // GCS re-renders #gsc-i-id1 on focus/blur/results, wiping any placeholder
     // we set. Re-apply via MutationObserver so it sticks. The icon swap also

--- a/src/components/header/SiteSearch.js
+++ b/src/components/header/SiteSearch.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react';
+import { swapSearchButtonIcon } from './searchIconSwap';
+
+const HOST_ID = 'gcse-search-host';
+const GCSE_SCRIPT_SRC = 'https://cse.google.com/cse.js?cx=b792c366f1ce73e3d';
+
+class SiteSearch extends Component {
+  componentDidMount() {
+    // Load Google Custom Search on demand and explicitly render the widget
+    // into our React-mounted host div. `parsetags: 'explicit'` keeps GCS from
+    // auto-scanning the page — we own the timing instead.
+    const renderGcseSearch = () => {
+      if (window.google && window.google.search && window.google.search.cse) {
+        try {
+          window.google.search.cse.element.render({
+            div: HOST_ID,
+            tag: 'search',
+          });
+        } catch (e) {
+          // Already rendered, or div not yet present — safe to ignore.
+        }
+      }
+    };
+
+    window.__gcse = {
+      parsetags: 'explicit',
+      callback: renderGcseSearch,
+    };
+
+    const gcseScript = document.createElement('script');
+    gcseScript.async = true;
+    gcseScript.src = GCSE_SCRIPT_SRC;
+    document.head.appendChild(gcseScript);
+
+    // GCS re-renders #gsc-i-id1 on focus/blur/results, wiping any placeholder
+    // we set. Re-apply via MutationObserver so it sticks. The icon swap also
+    // re-runs on every tick so the auro-icon survives GCS re-renders.
+    const applySearchCustomizations = () => {
+      const searchInput = document.querySelector('#gsc-i-id1');
+      if (searchInput && searchInput.getAttribute('placeholder') !== 'Search') {
+        searchInput.setAttribute('placeholder', 'Search');
+      }
+
+      swapSearchButtonIcon();
+    };
+
+    applySearchCustomizations();
+
+    const searchContainer = document.getElementById(HOST_ID);
+    if (searchContainer && typeof MutationObserver !== 'undefined') {
+      this.searchObserver = new MutationObserver(applySearchCustomizations);
+      this.searchObserver.observe(searchContainer, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['placeholder'],
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.searchObserver) {
+      this.searchObserver.disconnect();
+      this.searchObserver = null;
+    }
+  }
+
+  render() {
+    return <div id={HOST_ID} />;
+  }
+}
+
+export default SiteSearch;

--- a/src/components/header/ThemeSwitcher.js
+++ b/src/components/header/ThemeSwitcher.js
@@ -15,39 +15,46 @@ const detectCurrentTheme = () => {
 
 function ThemeSwitcher() {
   const switcherRef = useRef(null);
-  const [initialTheme] = useState(detectCurrentTheme);
+  const [theme, setTheme] = useState(detectCurrentTheme);
+  const isFirstRender = useRef(true);
+
+  // Apply the theme to <head> whenever it changes. Skip the first render so
+  // we don't redundantly re-inject the already-applied theme on mount.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    document.querySelectorAll('link[data-aag-theme]').forEach((link) => link.remove());
+
+    const addLink = (href) => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.dataset.aagTheme = '';
+      link.href = href;
+      document.head.appendChild(link);
+    };
+
+    addLink(`/tokens/web/${theme}.min.css`);
+    addLink(`/styles/bundled/themes/${theme}.global.min.css`);
+  }, [theme]);
 
   useEffect(() => {
     const el = switcherRef.current;
     if (!el) return undefined;
 
-    let currentTheme = initialTheme;
-
     const onInput = (e) => {
-      const theme = e.target.value;
-      if (!THEMES.includes(theme) || theme === currentTheme) return;
-      currentTheme = theme;
-
-      document.querySelectorAll('link[data-aag-theme]').forEach((link) => link.remove());
-
-      const addLink = (href) => {
-        const link = document.createElement('link');
-        link.rel = 'stylesheet';
-        link.dataset.aagTheme = '';
-        link.href = href;
-        document.head.appendChild(link);
-      };
-
-      addLink(`/tokens/web/${theme}.min.css`);
-      addLink(`/styles/bundled/themes/${theme}.global.min.css`);
+      if (THEMES.includes(e.target.value)) {
+        setTheme(e.target.value);
+      }
     };
 
     el.addEventListener('input', onInput);
     return () => el.removeEventListener('input', onInput);
-  }, [initialTheme]);
+  }, []);
 
   return (
-    <auro-select ref={switcherRef} id="theme-switcher" value={initialTheme} required>
+    <auro-select ref={switcherRef} id="theme-switcher" value={theme} required>
       <span slot="label">Site Theme</span>
       <auro-menu>
         {THEMES.map((t) => (

--- a/src/components/header/ThemeSwitcher.js
+++ b/src/components/header/ThemeSwitcher.js
@@ -1,13 +1,27 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const THEMES = ['alaska', 'hawaiian', 'atmos'];
 const DEFAULT_THEME = 'alaska';
 
+// Recover the active theme from the previously-injected token stylesheet so
+// that on remount we don't reset state back to alaska while hawaiian/atmos
+// links remain on <head>.
+const detectCurrentTheme = () => {
+  const tokenLink = document.querySelector('link[data-aag-theme][href*="/tokens/web/"]');
+  const href = tokenLink && tokenLink.getAttribute('href');
+  const match = href && href.match(/\/tokens\/web\/([^.]+)\.min\.css/);
+  return match && THEMES.includes(match[1]) ? match[1] : DEFAULT_THEME;
+};
+
 function ThemeSwitcher() {
   const switcherRef = useRef(null);
+  const [initialTheme] = useState(detectCurrentTheme);
 
   useEffect(() => {
-    let currentTheme = DEFAULT_THEME;
+    const el = switcherRef.current;
+    if (!el) return undefined;
+
+    let currentTheme = initialTheme;
 
     const onInput = (e) => {
       const theme = e.target.value;
@@ -28,13 +42,12 @@ function ThemeSwitcher() {
       addLink(`/styles/bundled/themes/${theme}.global.min.css`);
     };
 
-    const el = switcherRef.current;
     el.addEventListener('input', onInput);
     return () => el.removeEventListener('input', onInput);
-  }, []);
+  }, [initialTheme]);
 
   return (
-    <auro-select ref={switcherRef} id="theme-switcher" value={DEFAULT_THEME} required>
+    <auro-select ref={switcherRef} id="theme-switcher" value={initialTheme} required>
       <span slot="label">Site Theme</span>
       <auro-menu>
         {THEMES.map((t) => (

--- a/src/components/header/ThemeSwitcher.js
+++ b/src/components/header/ThemeSwitcher.js
@@ -1,0 +1,70 @@
+import React, { Component, createRef } from 'react';
+
+const ALLOWED_THEMES = ['alaska', 'hawaiian', 'atmos'];
+const DEFAULT_THEME = 'alaska';
+
+class ThemeSwitcher extends Component {
+  constructor() {
+    super();
+    this.state = {
+      siteTheme: DEFAULT_THEME,
+    };
+
+    this.switcherRef = createRef();
+    this.onInput = this.onInput.bind(this);
+  }
+
+  onInput(e) {
+    const theme = e.target.value;
+    const safeTheme = ALLOWED_THEMES.includes(theme) ? theme : this.state.siteTheme;
+
+    if (this.state.siteTheme === safeTheme) {
+      return;
+    }
+
+    this.setState({ siteTheme: safeTheme });
+
+    document.querySelectorAll('link[data-aag-theme]').forEach((link) => {
+      link.remove();
+    });
+
+    const newTokenLink = document.createElement('link');
+    newTokenLink.setAttribute('rel', 'stylesheet');
+    newTokenLink.setAttribute('data-aag-theme', '');
+    newTokenLink.setAttribute('href', `/tokens/web/${safeTheme}.min.css`);
+    document.head.appendChild(newTokenLink);
+
+    const newWcssLink = document.createElement('link');
+    newWcssLink.setAttribute('rel', 'stylesheet');
+    newWcssLink.setAttribute('data-aag-theme', '');
+    newWcssLink.setAttribute('href', `/styles/bundled/themes/${safeTheme}.global.min.css`);
+    document.head.appendChild(newWcssLink);
+  }
+
+  componentDidMount() {
+    if (this.switcherRef.current) {
+      this.switcherRef.current.addEventListener('input', this.onInput);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.switcherRef.current) {
+      this.switcherRef.current.removeEventListener('input', this.onInput);
+    }
+  }
+
+  render() {
+    return (
+      <auro-select ref={this.switcherRef} id="theme-switcher" value={DEFAULT_THEME} required>
+        <span slot="label">Site Theme</span>
+        <auro-menu>
+          <auro-menuoption value="alaska">Alaska</auro-menuoption>
+          <auro-menuoption value="hawaiian">Hawaiian</auro-menuoption>
+          <auro-menuoption value="atmos">Atmos</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    );
+  }
+}
+
+export default ThemeSwitcher;

--- a/src/components/header/ThemeSwitcher.js
+++ b/src/components/header/ThemeSwitcher.js
@@ -1,70 +1,50 @@
-import React, { Component, createRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
-const ALLOWED_THEMES = ['alaska', 'hawaiian', 'atmos'];
+const THEMES = ['alaska', 'hawaiian', 'atmos'];
 const DEFAULT_THEME = 'alaska';
 
-class ThemeSwitcher extends Component {
-  constructor() {
-    super();
-    this.state = {
-      siteTheme: DEFAULT_THEME,
+function ThemeSwitcher() {
+  const switcherRef = useRef(null);
+
+  useEffect(() => {
+    let currentTheme = DEFAULT_THEME;
+
+    const onInput = (e) => {
+      const theme = e.target.value;
+      if (!THEMES.includes(theme) || theme === currentTheme) return;
+      currentTheme = theme;
+
+      document.querySelectorAll('link[data-aag-theme]').forEach((link) => link.remove());
+
+      const addLink = (href) => {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.dataset.aagTheme = '';
+        link.href = href;
+        document.head.appendChild(link);
+      };
+
+      addLink(`/tokens/web/${theme}.min.css`);
+      addLink(`/styles/bundled/themes/${theme}.global.min.css`);
     };
 
-    this.switcherRef = createRef();
-    this.onInput = this.onInput.bind(this);
-  }
+    const el = switcherRef.current;
+    el.addEventListener('input', onInput);
+    return () => el.removeEventListener('input', onInput);
+  }, []);
 
-  onInput(e) {
-    const theme = e.target.value;
-    const safeTheme = ALLOWED_THEMES.includes(theme) ? theme : this.state.siteTheme;
-
-    if (this.state.siteTheme === safeTheme) {
-      return;
-    }
-
-    this.setState({ siteTheme: safeTheme });
-
-    document.querySelectorAll('link[data-aag-theme]').forEach((link) => {
-      link.remove();
-    });
-
-    const newTokenLink = document.createElement('link');
-    newTokenLink.setAttribute('rel', 'stylesheet');
-    newTokenLink.setAttribute('data-aag-theme', '');
-    newTokenLink.setAttribute('href', `/tokens/web/${safeTheme}.min.css`);
-    document.head.appendChild(newTokenLink);
-
-    const newWcssLink = document.createElement('link');
-    newWcssLink.setAttribute('rel', 'stylesheet');
-    newWcssLink.setAttribute('data-aag-theme', '');
-    newWcssLink.setAttribute('href', `/styles/bundled/themes/${safeTheme}.global.min.css`);
-    document.head.appendChild(newWcssLink);
-  }
-
-  componentDidMount() {
-    if (this.switcherRef.current) {
-      this.switcherRef.current.addEventListener('input', this.onInput);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.switcherRef.current) {
-      this.switcherRef.current.removeEventListener('input', this.onInput);
-    }
-  }
-
-  render() {
-    return (
-      <auro-select ref={this.switcherRef} id="theme-switcher" value={DEFAULT_THEME} required>
-        <span slot="label">Site Theme</span>
-        <auro-menu>
-          <auro-menuoption value="alaska">Alaska</auro-menuoption>
-          <auro-menuoption value="hawaiian">Hawaiian</auro-menuoption>
-          <auro-menuoption value="atmos">Atmos</auro-menuoption>
-        </auro-menu>
-      </auro-select>
-    );
-  }
+  return (
+    <auro-select ref={switcherRef} id="theme-switcher" value={DEFAULT_THEME} required>
+      <span slot="label">Site Theme</span>
+      <auro-menu>
+        {THEMES.map((t) => (
+          <auro-menuoption key={t} value={t}>
+            {t[0].toUpperCase() + t.slice(1)}
+          </auro-menuoption>
+        ))}
+      </auro-menu>
+    </auro-select>
+  );
 }
 
 export default ThemeSwitcher;

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -52,10 +52,29 @@ class Header extends Component {
       this.updateTheme(e.target.value);
     });
 
-    const searchInput = document.querySelector('#gsc-i-id1');
+    // GCS loads async and re-renders #gsc-i-id1 on focus/blur/results, wiping
+    // any placeholder we set. Re-apply via MutationObserver so it sticks.
+    const applyPlaceholder = () => {
+      const searchInput = document.querySelector('#gsc-i-id1');
+      if (searchInput && searchInput.getAttribute('placeholder') !== 'Search') {
+        searchInput.setAttribute('placeholder', 'Search');
+      }
+    };
 
-    if (searchInput) {
-      searchInput.setAttribute('placeholder', 'Search');
+    applyPlaceholder();
+
+    this.searchObserver = new MutationObserver(applyPlaceholder);
+    this.searchObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['placeholder'],
+    });
+  }
+
+  componentWillUnmount() {
+    if (this.searchObserver) {
+      this.searchObserver.disconnect();
     }
   }
   

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -63,13 +63,16 @@ class Header extends Component {
 
     applyPlaceholder();
 
-    this.searchObserver = new MutationObserver(applyPlaceholder);
-    this.searchObserver.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['placeholder'],
-    });
+    const searchContainer = document.querySelector('.gcse-search');
+    if (searchContainer && typeof MutationObserver !== 'undefined') {
+      this.searchObserver = new MutationObserver(applyPlaceholder);
+      this.searchObserver.observe(searchContainer, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['placeholder'],
+      });
+    }
   }
 
   componentWillUnmount() {

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import './style.scss';
+import { swapSearchButtonIcon } from './searchIconSwap';
 
 const ALLOWED_THEMES = ['alaska', 'hawaiian', 'atmos'];
 
@@ -57,18 +58,22 @@ class Header extends Component {
 
     // GCS loads async and re-renders #gsc-i-id1 on focus/blur/results, wiping
     // any placeholder we set. Re-apply via MutationObserver so it sticks.
-    const applyPlaceholder = () => {
+    // The icon swap (handled in searchIconSwap.js) also re-runs on every tick
+    // so the auro-icon stays in place across GCS re-renders.
+    const applySearchCustomizations = () => {
       const searchInput = document.querySelector('#gsc-i-id1');
       if (searchInput && searchInput.getAttribute('placeholder') !== 'Search') {
         searchInput.setAttribute('placeholder', 'Search');
       }
+
+      swapSearchButtonIcon();
     };
 
-    applyPlaceholder();
+    applySearchCustomizations();
 
     const searchContainer = document.querySelector('.gcse-search');
     if (searchContainer && typeof MutationObserver !== 'undefined') {
-      this.searchObserver = new MutationObserver(applyPlaceholder);
+      this.searchObserver = new MutationObserver(applySearchCustomizations);
       this.searchObserver.observe(searchContainer, {
         childList: true,
         subtree: true,

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import './style.scss';
-import { swapSearchButtonIcon } from './searchIconSwap';
+import SiteSearch from './SiteSearch';
 
 const ALLOWED_THEMES = ['alaska', 'hawaiian', 'atmos'];
 
@@ -13,7 +13,7 @@ class Header extends Component {
 
     this.updateTheme = this.updateTheme.bind(this);
   }
-  
+
   updateTheme(theme) {
     const safeTheme = ALLOWED_THEMES.includes(theme) ? theme : this.state.siteTheme;
 
@@ -45,7 +45,7 @@ class Header extends Component {
       document.head.appendChild(newWcssLink);
     }
   }
-  
+
   componentDidMount() {
     // Store refs to the element and handler so componentWillUnmount can
     // detach the listener if Header is ever unmounted/remounted.
@@ -55,47 +55,14 @@ class Header extends Component {
     };
 
     this.themeSwitcher.addEventListener('input', this.onThemeSwitcherInput);
-
-    // GCS loads async and re-renders #gsc-i-id1 on focus/blur/results, wiping
-    // any placeholder we set. Re-apply via MutationObserver so it sticks.
-    // The icon swap (handled in searchIconSwap.js) also re-runs on every tick
-    // so the auro-icon stays in place across GCS re-renders.
-    const applySearchCustomizations = () => {
-      const searchInput = document.querySelector('#gsc-i-id1');
-      if (searchInput && searchInput.getAttribute('placeholder') !== 'Search') {
-        searchInput.setAttribute('placeholder', 'Search');
-      }
-
-      swapSearchButtonIcon();
-    };
-
-    applySearchCustomizations();
-
-    const searchContainer = document.querySelector('.gcse-search');
-    if (searchContainer && typeof MutationObserver !== 'undefined') {
-      this.searchObserver = new MutationObserver(applySearchCustomizations);
-      this.searchObserver.observe(searchContainer, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['placeholder'],
-      });
-    }
   }
 
   componentWillUnmount() {
-    // Disconnect the placeholder observer to avoid leaking it across mounts.
-    if (this.searchObserver) {
-      this.searchObserver.disconnect();
-      this.searchObserver = null;
-    }
-
-    // Detach the theme-switcher listener registered in componentDidMount.
     if (this.themeSwitcher && this.onThemeSwitcherInput) {
       this.themeSwitcher.removeEventListener('input', this.onThemeSwitcherInput);
     }
   }
-  
+
   render() {
     return (
       <header className="siteHeader">
@@ -104,6 +71,7 @@ class Header extends Component {
           <span slot="subtitle">design system</span>
         </auro-lockup>
         <div className="header-bar">
+          <SiteSearch />
           <auro-select id="theme-switcher" className="theme-switcher" value="alaska" required>
             <span slot="label">Site Theme</span>
             <auro-menu>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,89 +1,21 @@
-import React, { Component } from "react";
+import React from "react";
 import './style.scss';
 import SiteSearch from './SiteSearch';
+import ThemeSwitcher from './ThemeSwitcher';
 
-const ALLOWED_THEMES = ['alaska', 'hawaiian', 'atmos'];
-
-class Header extends Component {
-  constructor() {
-    super();
-    this.state = {
-      siteTheme: 'alaska'
-    };
-
-    this.updateTheme = this.updateTheme.bind(this);
-  }
-
-  updateTheme(theme) {
-    const safeTheme = ALLOWED_THEMES.includes(theme) ? theme : this.state.siteTheme;
-
-    if (this.state.siteTheme !== safeTheme) {
-      this.state.siteTheme = safeTheme;
-      this.setState({ siteTheme: safeTheme });
-
-      document.querySelectorAll('link[data-aag-theme]').forEach((link) => {
-        link.remove();
-      });
-
-      const newTokenLink = document.createElement('link');
-      newTokenLink.setAttribute('rel', 'stylesheet');
-      newTokenLink.setAttribute('data-aag-theme', '');
-      newTokenLink.setAttribute('href', `/tokens/web/${this.state.siteTheme}.min.css`);
-
-      document.head.appendChild(newTokenLink);
-
-      const newWcssLink = document.createElement('link');
-      newWcssLink.setAttribute('rel', 'stylesheet');
-      newWcssLink.setAttribute('data-aag-theme', '');
-      let wcssHref = this.state.siteTheme;
-
-      if (this.state.siteTheme === 'atmos') {
-        wcssHref = 'atmos';
-      }
-
-      newWcssLink.setAttribute('href', `/styles/bundled/themes/${wcssHref}.global.min.css`);
-      document.head.appendChild(newWcssLink);
-    }
-  }
-
-  componentDidMount() {
-    // Store refs to the element and handler so componentWillUnmount can
-    // detach the listener if Header is ever unmounted/remounted.
-    this.themeSwitcher = document.querySelector('#theme-switcher');
-    this.onThemeSwitcherInput = (e) => {
-      this.updateTheme(e.target.value);
-    };
-
-    this.themeSwitcher.addEventListener('input', this.onThemeSwitcherInput);
-  }
-
-  componentWillUnmount() {
-    if (this.themeSwitcher && this.onThemeSwitcherInput) {
-      this.themeSwitcher.removeEventListener('input', this.onThemeSwitcherInput);
-    }
-  }
-
-  render() {
-    return (
-      <header className="siteHeader">
-        <auro-lockup>
-          <span slot="title">Auro</span>
-          <span slot="subtitle">design system</span>
-        </auro-lockup>
-        <div className="header-bar">
-          <SiteSearch />
-          <auro-select id="theme-switcher" className="theme-switcher" value="alaska" required>
-            <span slot="label">Site Theme</span>
-            <auro-menu>
-              <auro-menuoption value="alaska">Alaska</auro-menuoption>
-              <auro-menuoption value="hawaiian">Hawaiian</auro-menuoption>
-              <auro-menuoption value="atmos">Atmos</auro-menuoption>
-            </auro-menu>
-          </auro-select>
-        </div>
-      </header>
-    );
-  }
+function Header() {
+  return (
+    <header className="siteHeader">
+      <auro-lockup>
+        <span slot="title">Auro</span>
+        <span slot="subtitle">design system</span>
+      </auro-lockup>
+      <div className="header-bar">
+        <SiteSearch />
+        <ThemeSwitcher />
+      </div>
+    </header>
+  );
 }
 
 export default Header;

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -46,11 +46,14 @@ class Header extends Component {
   }
   
   componentDidMount() {
-    const themeSwitcher = document.querySelector('#theme-switcher');
-
-    themeSwitcher.addEventListener('input', (e) => {
+    // Store refs to the element and handler so componentWillUnmount can
+    // detach the listener if Header is ever unmounted/remounted.
+    this.themeSwitcher = document.querySelector('#theme-switcher');
+    this.onThemeSwitcherInput = (e) => {
       this.updateTheme(e.target.value);
-    });
+    };
+
+    this.themeSwitcher.addEventListener('input', this.onThemeSwitcherInput);
 
     // GCS loads async and re-renders #gsc-i-id1 on focus/blur/results, wiping
     // any placeholder we set. Re-apply via MutationObserver so it sticks.
@@ -76,8 +79,15 @@ class Header extends Component {
   }
 
   componentWillUnmount() {
+    // Disconnect the placeholder observer to avoid leaking it across mounts.
     if (this.searchObserver) {
       this.searchObserver.disconnect();
+      this.searchObserver = null;
+    }
+
+    // Detach the theme-switcher listener registered in componentDidMount.
+    if (this.themeSwitcher && this.onThemeSwitcherInput) {
+      this.themeSwitcher.removeEventListener('input', this.onThemeSwitcherInput);
     }
   }
   

--- a/src/components/header/searchIconSwap.js
+++ b/src/components/header/searchIconSwap.js
@@ -8,10 +8,6 @@
 // Because we don't own the GCS markup, the swap must run after GCS hydrates the
 // button and re-run whenever GCS re-renders it. The caller is responsible for
 // invoking `swapSearchButtonIcon` on mount and from a MutationObserver.
-//
-// To revert this behavior, delete this file, remove the import + call from
-// `src/components/header/index.js`, and delete the matching
-// `.gsc-search-button-v2 svg { display: none }` rule in `src/sass/App.scss`.
 // =============================================================================
 
 const SEARCH_BUTTON_SELECTOR = '.gsc-search-button-v2';

--- a/src/components/header/searchIconSwap.js
+++ b/src/components/header/searchIconSwap.js
@@ -29,4 +29,9 @@ export function swapSearchButtonIcon() {
   icon.setAttribute('name', 'arrow-right');
   icon.setAttribute('customColor', '');
   searchButton.appendChild(icon);
+
+  // Marker the CSS keys off so GCS's original SVG is only hidden once the
+  // replacement icon is actually in the DOM — avoids an empty button if this
+  // function ever fails to run.
+  searchButton.dataset.iconSwapped = '';
 }

--- a/src/components/header/searchIconSwap.js
+++ b/src/components/header/searchIconSwap.js
@@ -10,7 +10,7 @@
 // invoking `swapSearchButtonIcon` on mount and from a MutationObserver.
 // =============================================================================
 
-const SEARCH_BUTTON_SELECTOR = '.gsc-search-button-v2';
+const SEARCH_BUTTON_SELECTOR = '#gcse-search-host .gsc-search-button-v2';
 
 export function swapSearchButtonIcon() {
   const searchButton = document.querySelector(SEARCH_BUTTON_SELECTOR);

--- a/src/components/header/searchIconSwap.js
+++ b/src/components/header/searchIconSwap.js
@@ -10,6 +10,8 @@
 // invoking `swapSearchButtonIcon` on mount and from a MutationObserver.
 // =============================================================================
 
+// Scoped under #gcse-search-host so the swap stays isolated to this header's
+// GCS instance and matches the scoped CSS rules in `src/sass/App.scss`.
 const SEARCH_BUTTON_SELECTOR = '#gcse-search-host .gsc-search-button-v2';
 
 export function swapSearchButtonIcon() {

--- a/src/components/header/searchIconSwap.js
+++ b/src/components/header/searchIconSwap.js
@@ -1,0 +1,34 @@
+// =============================================================================
+// Search button icon swap
+// -----------------------------------------------------------------------------
+// Google Custom Search (GCS) renders a magnifier SVG inside the search submit
+// button, which is redundant with the magnifier shown inside the input itself.
+// We replace it with the Auro `arrow-right` icon to read as "submit" instead.
+//
+// Because we don't own the GCS markup, the swap must run after GCS hydrates the
+// button and re-run whenever GCS re-renders it. The caller is responsible for
+// invoking `swapSearchButtonIcon` on mount and from a MutationObserver.
+//
+// To revert this behavior, delete this file, remove the import + call from
+// `src/components/header/index.js`, and delete the matching
+// `.gsc-search-button-v2 svg { display: none }` rule in `src/sass/App.scss`.
+// =============================================================================
+
+const SEARCH_BUTTON_SELECTOR = '.gsc-search-button-v2';
+
+export function swapSearchButtonIcon() {
+  const searchButton = document.querySelector(SEARCH_BUTTON_SELECTOR);
+  if (!searchButton || searchButton.querySelector('auro-icon')) {
+    return;
+  }
+
+  while (searchButton.firstChild) {
+    searchButton.removeChild(searchButton.firstChild);
+  }
+
+  const icon = document.createElement('auro-icon');
+  icon.setAttribute('category', 'interface');
+  icon.setAttribute('name', 'arrow-right');
+  icon.setAttribute('customColor', '');
+  searchButton.appendChild(icon);
+}

--- a/src/components/header/searchIconSwap.js
+++ b/src/components/header/searchIconSwap.js
@@ -25,6 +25,17 @@ export function swapSearchButtonIcon() {
     return;
   }
 
+  // If auro-icon hasn't registered yet, leave GCS's original SVG in place so
+  // the CSS fallback (gcs-svg-fallback animation in App.scss) can reveal it
+  // instead of us committing the swap to an invisible custom element. Retry
+  // once the element is defined.
+  if (!window.customElements || !window.customElements.get('auro-icon')) {
+    if (window.customElements && window.customElements.whenDefined) {
+      window.customElements.whenDefined('auro-icon').then(swapSearchButtonIcon);
+    }
+    return;
+  }
+
   const icon = document.createElement('auro-icon');
   icon.setAttribute('category', 'interface');
   icon.setAttribute('name', 'arrow-right');

--- a/src/components/header/searchIconSwap.js
+++ b/src/components/header/searchIconSwap.js
@@ -10,25 +10,30 @@
 // invoking `swapSearchButtonIcon` on mount and from a MutationObserver.
 // =============================================================================
 
+export const HOST_ID = 'gcse-search-host';
+
 // Scoped under #gcse-search-host so the swap stays isolated to this header's
 // GCS instance and matches the scoped CSS rules in `src/sass/App.scss`.
-const SEARCH_BUTTON_SELECTOR = '#gcse-search-host .gsc-search-button-v2';
+const SEARCH_BUTTON_SELECTOR = `#${HOST_ID} .gsc-search-button-v2`;
 
 export function swapSearchButtonIcon() {
   const searchButton = document.querySelector(SEARCH_BUTTON_SELECTOR);
-  if (!searchButton || searchButton.querySelector('auro-icon')) {
+  // `data-icon-swapped` is wiped whenever GCS re-renders the button, so checking
+  // it is enough to detect both first-run and re-render cases — and is cheaper
+  // than a child-element query on every MutationObserver tick.
+  if (!searchButton || searchButton.dataset.iconSwapped !== undefined) {
     return;
-  }
-
-  while (searchButton.firstChild) {
-    searchButton.removeChild(searchButton.firstChild);
   }
 
   const icon = document.createElement('auro-icon');
   icon.setAttribute('category', 'interface');
   icon.setAttribute('name', 'arrow-right');
   icon.setAttribute('customColor', '');
-  searchButton.appendChild(icon);
+  searchButton.replaceChildren(icon);
+
+  // auro-icon is decorative; restore the button's accessible name after we
+  // replace GCS's title/text content.
+  searchButton.setAttribute('aria-label', 'Search');
 
   // Marker the CSS keys off so GCS's original SVG is only hidden once the
   // replacement icon is actually in the DOM — avoids an empty button if this

--- a/src/components/header/style.scss
+++ b/src/components/header/style.scss
@@ -24,8 +24,7 @@
   flex-direction: row;
   z-index: var(--ds-depth-overlay);
   align-items: center;
-  // offset to account for margin by GCS on the search wrapper
-  gap: calc(var(--ds-size-300) - 1px);
+  gap: var(--ds-size-300);
   padding-right: var(--ds-size-100);
 
   #theme-switcher {

--- a/src/components/header/style.scss
+++ b/src/components/header/style.scss
@@ -24,6 +24,8 @@
   flex-direction: row;
   z-index: var(--ds-depth-overlay);
   align-items: center;
+  // offset to account for margin by GCS on the search wrapper
+  gap: calc(var(--ds-size-300) - 1px);
   padding-right: var(--ds-size-100);
 
   #theme-switcher {

--- a/src/components/header/style.scss
+++ b/src/components/header/style.scss
@@ -10,7 +10,8 @@
   padding: 10px;
   position: sticky;
   top: 0;
-  z-index: 10;
+  // Must clear .sidenav
+  z-index: var(--ds-depth-overlay);
   border-bottom: 1px solid var(--auro-color-border-primary-on-light);
   background-color: white;
 

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -55,8 +55,7 @@ $sideNavTop: 86px;
 }
 
 .gsc-input-box {
-  border-right: 0 !important;
-  border-radius: 6px 0 0 6px !important;
+  border-radius: 6px !important;
   border-color: var(--ds-basic-color-border-bold) !important;
 }
 

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -68,23 +68,34 @@ $sideNavTop: 86px;
 }
 
 .gsc-search-button-v2 {
-  line-height: 1.5;
+  line-height: 1;
   padding: 10px;
   background-color: var(--ds-advanced-color-button-primary-background) !important;
   border-color: var(--ds-basic-color-border-bold) !important;
   border-left: 0 !important;
+  position: relative;
+  color: var(--ds-advanced-color-button-primary-text) !important;
 
+  // Hide the GCS magnifier SVG; we replace it with an arrow via ::after to
+  // avoid duplicating the search icon already shown inside the input.
   svg {
-    fill: var(--ds-advanced-color-button-primary-text) !important;
+    display: none !important;
+  }
+
+  &::after {
+    content: '';
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: var(--ds-advanced-color-button-primary-text);
+    mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M5 12h12m-5-6 6 6-6 6' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/></svg>") no-repeat center / contain;
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M5 12h12m-5-6 6 6-6 6' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/></svg>") no-repeat center / contain;
   }
 
   &:hover {
     background-color: var(--ds-advanced-color-button-primary-background-hover) !important;
     border-color: var(--ds-advanced-color-button-primary-border-hover) !important;
-
-    svg {
-      fill: var(--ds-advanced-color-button-primary-text) !important;
-    }
+    cursor: pointer;
   }
 }
 

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -64,6 +64,7 @@ $sideNavTop: 86px;
   margin-left: 0 !important;
   border-radius: 0 6px 6px 0 !important;
   height: 58px !important;
+  width: 58px !important;
 }
 
 .gsc-search-button-v2 {

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -40,7 +40,7 @@ $sideNavTop: 86px;
 
   @include auro_breakpoint($min: $ds-grid-breakpoint-md) {
     display: block;
-    width: 250px !important;
+    width: 350px !important;
   }
 }
 

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -28,15 +28,11 @@ $sideNavTop: 86px;
 
 // customization for use with the google search widget
 .gsc-control-cse {
-  position: fixed;
-  top: 12px;
-  right: 165px;
-  z-index: var(--ds-depth-overlay);
   width: 150px;
   display: none;
   padding: 0 !important;
-
-  box-shadow: inset 0 0 0 1px var(--ds-auro-dropdown-trigger-outline-color);
+  background: transparent;
+  box-shadow: none;
 
   @include auro_breakpoint($min: $ds-grid-breakpoint-md) {
     display: block;
@@ -46,6 +42,9 @@ $sideNavTop: 86px;
 
 .gsc-search-box {
   margin: 0 !important;
+  // GCS renders the input + submit as a <table>; collapse its border-spacing
+  // so the 8px gap below comes from our padding alone.
+  border-spacing: 0 !important;
 }
 
 .gsc-input {
@@ -59,26 +58,51 @@ $sideNavTop: 86px;
   border-color: var(--ds-basic-color-border-bold) !important;
 }
 
-.gsc-search-button {
-  display: block !important;
-  margin-left: 0 !important;
-  border-radius: 0 6px 6px 0 !important;
-  height: 58px !important;
-  width: 58px !important;
+// GCS renders a `.gsc-clear-button` <td> between the input cell and the
+// submit. Even with nothing visible inside, it carries width that bleeds
+// into the gap. Nullify it so the gap below is the single source of truth.
+#gcse-search-host .gsc-clear-button {
+  display: none !important;
+  width: 0 !important;
+  padding: 0 !important;
 }
 
-.gsc-search-button-v2 {
+// GCS injects its own stylesheet at script load time with
+// `.gsc-search-button { display: none !important }` (used for the v1 button).
+// Scope under `#gcse-search-host` to beat it on specificity.
+//
+// This is the ONE place the input-to-button gap is set. Border-spacing on
+// the table is zeroed above; the clear-button cell is collapsed above; so
+// `padding-left` here is the entire visible gap.
+#gcse-search-host .gsc-search-button {
+  display: block !important;
+  // GCS sets `margin-left: 2px` on this <td>; zero it so padding is the
+  // sole contributor to the gap.
+  margin-left: 0;
+  padding: 0 0 0 var(--ds-size-100);
+  background: transparent;
+}
+
+#gcse-search-host .gsc-search-button-v2 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1;
-  padding: 10px;
-  background-color: var(--ds-advanced-color-button-primary-background) !important;
-  border-color: var(--ds-basic-color-border-bold) !important;
-  border-left: 0 !important;
-  color: var(--ds-advanced-color-button-primary-text) !important;
+  // GCS sets `margin-left: 2px` on the button; zero it so the gap is owned
+  // by the parent <td>'s padding-left alone.
+  margin-left: 0;
+  padding: 0;
+  width: 58px;
+  height: 58px;
+  background-color: var(--ds-advanced-color-button-primary-background);
+  border-color: var(--ds-basic-color-border-bold);
+  border-radius: 6px;
+  color: var(--ds-advanced-color-button-primary-text);
 
   // Hide GCS's original magnifier SVG so it doesn't flash before
   // searchIconSwap.js replaces it with auro-icon arrow-right.
   > svg {
-    display: none !important;
+    display: none;
   }
 
   auro-icon {

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -1,8 +1,3 @@
-// Auro Support
-/* ------------------------ Auro Support ------------------------ */
-/* auro tokens for legacy components */
-// @import '@alaskaairux/design-tokens/dist/tokens/SCSSVariables';
-
 @import '@aurodesignsystem/design-tokens/dist/legacy/auro-classic/SCSSVariables';
 @import "@aurodesignsystem/webcorestylesheets/src/breakpoints";
 @import "@aurodesignsystem/webcorestylesheets/src/animation";
@@ -42,8 +37,7 @@ $sideNavTop: 86px;
 
 .gsc-search-box {
   margin: 0 !important;
-  // GCS renders the input + submit as a <table>; collapse its border-spacing
-  // so the 8px gap below comes from our padding alone.
+  // GCS renders the input + submit as a <table>
   border-spacing: 0 !important;
 }
 
@@ -58,7 +52,7 @@ $sideNavTop: 86px;
   border-color: var(--ds-basic-color-border-bold) !important;
 }
 
-// GCS renders a `.gsc-clear-button` <td> between the input cell and the
+// GCS renders a .gsc-clear-button <td> between the input cell and the
 // submit. Even with nothing visible inside, it carries width that bleeds
 // into the gap. Nullify it so the gap below is the single source of truth.
 #gcse-search-host .gsc-clear-button {
@@ -68,28 +62,21 @@ $sideNavTop: 86px;
 }
 
 // GCS injects its own stylesheet at script load time with
-// `.gsc-search-button { display: none !important }` (used for the v1 button).
-// Scope under `#gcse-search-host` to beat it on specificity.
-//
-// This is the ONE place the input-to-button gap is set. Border-spacing on
-// the table is zeroed above; the clear-button cell is collapsed above; so
-// `padding-left` here is the entire visible gap.
+// .gsc-search-button. Scope under #gcse-search-host to beat it on specificity.
 #gcse-search-host .gsc-search-button {
   display: block !important;
-  // GCS sets `margin-left: 2px` on this <td>; zero it so padding is the
-  // sole contributor to the gap.
   margin-left: 0;
   padding: 0 0 0 var(--ds-size-100);
   background: transparent;
 }
 
+// GCS injects its own stylesheet at script load time with
+// .gsc-search-button. Scope under #gcse-search-host to beat it on specificity.
 #gcse-search-host .gsc-search-button-v2 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   line-height: 1;
-  // GCS sets `margin-left: 2px` on the button; zero it so the gap is owned
-  // by the parent <td>'s padding-left alone.
   margin-left: 0;
   padding: 0;
   width: 58px;
@@ -100,7 +87,7 @@ $sideNavTop: 86px;
   color: var(--ds-advanced-color-button-primary-text);
 
   // Hide GCS's original magnifier SVG so it doesn't flash before
-  // searchIconSwap.js replaces it with auro-icon arrow-right.
+  // searchIconSwap.js replaces it with auro-icon.
   > svg {
     display: none;
   }
@@ -210,51 +197,27 @@ footer,
 .wrapper > section {
   margin: var(--ds-size-400);
   padding-top: var(--ds-size-200);
-  // padding: var(--ds-size-200) var(--ds-size-200) 0;
-  // margin: var(--ds-size-200) auto 0 230px;
 
   @include auro_breakpoint($min: $ds-grid-breakpoint-sm) {
     padding: var(--ds-size-200) var(--ds-size-200) 0;
     margin: 0 auto 0 230px;
-  //   // max-width: 55%;
-  //   margin: var(--ds-size-200) auto 0 250px;
   }
-
-  // @include auro_breakpoint($min: $ds-grid-breakpoint-md) {
-  //   // max-width: 60%;
-  //   margin: var(--ds-size-200) auto 0 290px;
-  // }
-
-  // @include auro_breakpoint($min: $ds-grid-breakpoint-xl) {
-  //   // max-width: 64rem;
-  //   margin: var(--ds-size-200) auto 0 25%;
-  // }
 }
 
 footer {
-  margin: 0; //  0 0 230px;
+  margin: 0;
   text-align: center;
 }
 
-// .auro-markdown ~ footer {
-//   margin: 0 0 0 230px;
-//   // text-align: center;
-
-//   background-color: aquamarine;
-// }
 // -=-=-=-=-=-=-=-=-= body wrapper -=-=-=-=-=-=-=-=-=-=-=
-
 .auro_baseType {
-  // background-color: lime;
   display: flex;
   flex-direction: column;
 }
 
 .auro-markdown {
-  // background-color: orange;
   height: calc(100vh - 35px - 58px - 16px - 52px);
   overflow-y: auto;
-  // margin-top: var(--ds-size-400) !important;
 }
 
 footer {
@@ -317,14 +280,11 @@ auro-swatch-list {
     display: block;
     opacity: 1;
     left: auto;
-    // width: 180px;
     top: $sideNavTop;
     padding-bottom: 100px;
   }
 
-  // @include auro_breakpoint($min: $ds-grid-breakpoint-md) {
-    width: 230px;
-  // }
+  width: 230px;
 }
 
 .hyperlink.active,
@@ -446,7 +406,7 @@ code:not(.html):not(.css):not(.js) {
   margin-bottom: var(--ds-size-600);
 }
 
-// animation speed for auro-loader //
+// animation speed for auro-loader
 .slow::part(element) {
   animation-duration: 8s;
 }
@@ -583,7 +543,6 @@ pre {
     }
   }
 }
-// ----------------------------------------------
 
 // ------------ color view -----------------
 .avatarWrapper {
@@ -616,8 +575,6 @@ pre {
     padding-right: 5%;
   }
 }
-// -------------------------------------------
-
 
 // ----------- color transparency view ------------------------
 .transparencyBlock {
@@ -677,6 +634,7 @@ pre {
 .auro-rgb-color-brand-alpine-400--90 {
   background-color: color-mix(in srgb, var(--ds-color-brand-alpine-400) 90%, transparent);
 }
+
 // -------------------------------------------------------------
 
 .link {
@@ -694,7 +652,6 @@ pre {
 .tabList {
   height: auto;
   line-height: 1.5rem !important;
-  // margin-bottom: 2rem;
   position: sticky;
   top: $sideNavTop;
   background: linear-gradient(180deg, rgba(255,255,255,.99) 0%, rgba(255,255,255,1) 50%, rgba(255,255,255,.9) 100%);
@@ -755,7 +712,6 @@ pre {
   outline: unset;
 }
 
-// this really should be done in the component?
 auro-tokens-list {
   display: block;
   overflow: scroll;
@@ -776,7 +732,6 @@ img[src*='shields.io'] {
   white-space: nowrap;
 }
 
-
 // release views
 .releaseWrapper {
   margin: var(--ds-size-300) 0;
@@ -792,10 +747,8 @@ img[src*='shields.io'] {
   }
 }
 
-
 // CSS Loader
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-// Pretty sure this was replaced with auro-loader work
 .isLoading {
   color: var(--ds-color-background-darker);
   font-size: 80px;
@@ -890,7 +843,6 @@ img[src*='shields.io'] {
 
 // Sticky headers
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-// Something to support in Auro table?
 .auro_table--audit {
   th {
     white-space: nowrap;

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -86,9 +86,10 @@ $sideNavTop: 86px;
   border-radius: 6px;
   color: var(--ds-advanced-color-button-primary-text);
 
-  // Hide GCS's original magnifier SVG so it doesn't flash before
-  // searchIconSwap.js replaces it with auro-icon.
-  > svg {
+  // Hide GCS's original magnifier SVG only after searchIconSwap.js has
+  // replaced it with auro-icon (marked via data-icon-swapped). Keeps the
+  // submit button from rendering empty if the swap ever fails to run.
+  &[data-icon-swapped] > svg {
     display: none;
   }
 

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -85,11 +85,22 @@ $sideNavTop: 86px;
     border-radius: 6px;
     color: var(--ds-advanced-color-button-primary-text);
 
-    // Hide GCS's original magnifier SVG only after searchIconSwap.js has
-    // replaced it with auro-icon (marked via data-icon-swapped). Keeps the
-    // submit button from rendering empty if the swap ever fails to run.
+    // GCS's default magnifier SVG is hidden up front to avoid a flash before
+    // searchIconSwap.js replaces it with auro-icon. The `[data-icon-swapped]`
+    // gating below is the SAFETY NET — if the swap ever fails to run (auro-icon
+    // WC not registered, JS error, CSP block, etc.) the animation re-reveals
+    // the SVG after 1s so the button is never permanently iconless.
+    //
+    // DO NOT remove the `[data-icon-swapped]` selector or the animation without
+    // also hardening the JS swap — see searchIconSwap.js.
+    > svg {
+      opacity: 0;
+      animation: gcs-svg-fallback 0.2s 1s forwards;
+    }
+
     &[data-icon-swapped] > svg {
       display: none;
+      animation: none;
     }
 
     auro-icon {
@@ -102,6 +113,13 @@ $sideNavTop: 86px;
       cursor: pointer;
     }
   }
+}
+
+// Safety-net reveal for GCS's default magnifier — see #gcse-search-host
+// .gsc-search-button-v2 > svg above. Paired with the [data-icon-swapped]
+// gating; do not remove independently.
+@keyframes gcs-svg-fallback {
+  to { opacity: 1; }
 }
 
 .gs-title {

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -21,86 +21,86 @@ body {
 $sideNavHeight: 120px;
 $sideNavTop: 86px;
 
-// customization for use with the google search widget
-.gsc-control-cse {
-  width: 150px;
-  display: none;
-  padding: 0 !important;
-  background: transparent;
-  box-shadow: none;
-
-  @include auro_breakpoint($min: $ds-grid-breakpoint-md) {
-    display: block;
-    width: 350px !important;
-  }
-}
-
-.gsc-search-box {
-  margin: 0 !important;
-  // GCS renders the input + submit as a <table>
-  border-spacing: 0 !important;
-}
-
-.gsc-input {
-  padding-right: 0 !important;
-  background: unset !important;
-  height: 48px !important;
-}
-
-.gsc-input-box {
-  border-radius: 6px !important;
-  border-color: var(--ds-basic-color-border-bold) !important;
-}
-
-// GCS renders a .gsc-clear-button <td> between the input cell and the
-// submit. Even with nothing visible inside, it carries width that bleeds
-// into the gap. Nullify it so the gap below is the single source of truth.
-#gcse-search-host .gsc-clear-button {
-  display: none !important;
-  width: 0 !important;
-  padding: 0 !important;
-}
-
-// GCS injects its own stylesheet at script load time with
-// .gsc-search-button. Scope under #gcse-search-host to beat it on specificity.
-#gcse-search-host .gsc-search-button {
-  display: block !important;
-  margin-left: 0;
-  padding: 0 0 0 var(--ds-size-100);
-  background: transparent;
-}
-
-// GCS injects its own stylesheet at script load time with
-// .gsc-search-button. Scope under #gcse-search-host to beat it on specificity.
-#gcse-search-host .gsc-search-button-v2 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-  margin-left: 0;
-  padding: 0;
-  width: 58px;
-  height: 58px;
-  background-color: var(--ds-advanced-color-button-primary-background);
-  border-color: var(--ds-basic-color-border-bold);
-  border-radius: 6px;
-  color: var(--ds-advanced-color-button-primary-text);
-
-  // Hide GCS's original magnifier SVG only after searchIconSwap.js has
-  // replaced it with auro-icon (marked via data-icon-swapped). Keeps the
-  // submit button from rendering empty if the swap ever fails to run.
-  &[data-icon-swapped] > svg {
+// customization for use with the google search widget.
+// All rules scoped under #gcse-search-host so they only apply to this header's
+// GCS instance and beat GCS's class-only injected stylesheet on specificity.
+#gcse-search-host {
+  .gsc-control-cse {
+    width: 150px;
     display: none;
+    padding: 0 !important;
+    background: transparent;
+    box-shadow: none;
+
+    @include auro_breakpoint($min: $ds-grid-breakpoint-md) {
+      display: block;
+      width: 350px !important;
+    }
   }
 
-  auro-icon {
+  .gsc-search-box {
+    margin: 0 !important;
+    // GCS renders the input + submit as a <table>
+    border-spacing: 0 !important;
+  }
+
+  .gsc-input {
+    padding-right: 0 !important;
+    background: unset !important;
+    height: 48px !important;
+  }
+
+  .gsc-input-box {
+    border-radius: 6px !important;
+    border-color: var(--ds-basic-color-border-bold) !important;
+  }
+
+  // GCS renders a .gsc-clear-button <td> between the input cell and the
+  // submit. Even with nothing visible inside, it carries width that bleeds
+  // into the gap. Nullify it so the gap below is the single source of truth.
+  .gsc-clear-button {
+    display: none !important;
+    width: 0 !important;
+    padding: 0 !important;
+  }
+
+  .gsc-search-button {
+    display: block !important;
+    margin-left: 0;
+    padding: 0 0 0 var(--ds-size-100);
+    background: transparent;
+  }
+
+  .gsc-search-button-v2 {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    margin-left: 0;
+    padding: 0;
+    width: 58px;
+    height: 58px;
+    background-color: var(--ds-advanced-color-button-primary-background);
+    border-color: var(--ds-basic-color-border-bold);
+    border-radius: 6px;
     color: var(--ds-advanced-color-button-primary-text);
-  }
 
-  &:hover {
-    background-color: var(--ds-advanced-color-button-primary-background-hover) !important;
-    border-color: var(--ds-advanced-color-button-primary-border-hover) !important;
-    cursor: pointer;
+    // Hide GCS's original magnifier SVG only after searchIconSwap.js has
+    // replaced it with auro-icon (marked via data-icon-swapped). Keeps the
+    // submit button from rendering empty if the swap ever fails to run.
+    &[data-icon-swapped] > svg {
+      display: none;
+    }
+
+    auro-icon {
+      color: var(--ds-advanced-color-button-primary-text);
+    }
+
+    &:hover {
+      background-color: var(--ds-advanced-color-button-primary-background-hover) !important;
+      border-color: var(--ds-advanced-color-button-primary-border-hover) !important;
+      cursor: pointer;
+    }
   }
 }
 

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -73,23 +73,16 @@ $sideNavTop: 86px;
   background-color: var(--ds-advanced-color-button-primary-background) !important;
   border-color: var(--ds-basic-color-border-bold) !important;
   border-left: 0 !important;
-  position: relative;
   color: var(--ds-advanced-color-button-primary-text) !important;
 
-  // Hide the GCS magnifier SVG; we replace it with an arrow via ::after to
-  // avoid duplicating the search icon already shown inside the input.
-  svg {
+  // Hide GCS's original magnifier SVG so it doesn't flash before
+  // searchIconSwap.js replaces it with auro-icon arrow-right.
+  > svg {
     display: none !important;
   }
 
-  &::after {
-    content: '';
-    display: inline-block;
-    width: 20px;
-    height: 20px;
-    background-color: var(--ds-advanced-color-button-primary-text);
-    mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M5 12h12m-5-6 6 6-6 6' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/></svg>") no-repeat center / contain;
-    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M5 12h12m-5-6 6 6-6 6' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/></svg>") no-repeat center / contain;
+  auro-icon {
+    color: var(--ds-advanced-color-button-primary-text);
   }
 
   &:hover {


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Search input fixes

Design review by @forrest-for-real ✅

- Fix `border-radius` adjustment for Search input so its right side does not appear visually cut off
- Re-apply the `Search` placeholder on the search input so it doesn't intermittently disappear
  - Google CSE loads async and can rewrite the input on focus/blur/results — wiping any placeholder set once at mount.
- Make the search submit button square so it visually balances the input
- Widen the search input from 250px to 350px at the `md` breakpoint for more comfortable query length
- Replace the redundant magnifier inside the submit button with `<auro-icon category="interface" name="arrow-right">` so the button reads as "submit" rather than duplicating the magnifier shown inside the input
  - Encapsulated in `src/components/header/searchIconSwap.js` so the swap can be reverted in a single step (delete file + drop import/call from `SiteSearch` + drop the `[data-icon-swapped] > svg` rule)
  - GCS's original SVG starts at `opacity: 0` so it doesn't flash before the auro-icon is appended
- Add `cursor: pointer` on the submit button hover state
- Add `aria-label="Search"` to the swapped submit button since `auro-icon` is decorative — preserves the accessible name GCS originally provided via its title/SVG
- Wait for `customElements.whenDefined('auro-icon')` before committing the swap so we never replace GCS's SVG with an unregistered (invisible) custom element
- CSS safety-net: if the swap ever fails to run (auro-icon WC not registered, JS error, CSP block, etc.), a `gcs-svg-fallback` keyframe re-reveals GCS's original SVG after 1s so the button is never permanently iconless. Gated by `[data-icon-swapped]` so it's suppressed once the swap succeeds.
- Nullify the empty `.gsc-clear-button` cell GCS renders between the input and submit `<td>`s so it stops bleeding width into the gap — `gap: var(--ds-size-300)` on `.header-bar` is now the single source of truth for input↔button spacing
- Scope all GCS CSS overrides under `#gcse-search-host` so they only apply to this header's GCS instance and don't leak to any other CSE widget on the page

## Header / GCSE script loading

- Move the Google CSE `<script async src="...">` and `<div class="gcse-search">` out of `index.html` and into `SiteSearch.js`, loaded on demand
- Use `parsetags: 'explicit'` and `window.google.search.cse.element.render({ div: HOST_ID, tag: 'search' })` so GCS renders into a React-mounted host instead of auto-scanning the page — we own the timing
- Prevent duplicate GCSE script injection on remount / HMR. Three cases handled:
  1. No script yet → inject; the `window.__gcse.callback` we install fires on load
  2. Script present and API ready → render directly
  3. Script present but API not yet ready → do nothing; the callback we just installed fires when load finishes
- On unmount, only delete `window.__gcse` if it still points at this mount's closure, so a remount that already installed a fresh callback isn't clobbered
- Fix z-index on `.siteHeader`: bump from `10` → `var(--ds-depth-overlay)` so the header (and the GCS results popup it anchors) renders above `.sidenav` instead of behind it

## Header refactor

- Split the monolithic `Header` class component into three focused components:
  - `Header` (`src/components/header/index.js`) — lockup + layout shell only
  - `SiteSearch` (`src/components/header/SiteSearch.js`) — owns GCSE script loading, render, MutationObserver, placeholder re-apply, and icon-swap invocation
  - `ThemeSwitcher` (`src/components/header/ThemeSwitcher.js`) — owns theme state and `<link>` injection
- Convert both new components to functional components with hooks for clearer effect/cleanup pairing
- `ThemeSwitcher` recovers the active theme from the previously-injected `link[data-aag-theme]` stylesheet on mount so remount/HMR doesn't reset state back to `alaska` while `hawaiian`/`atmos` links remain on `<head>`
- Skip the first render in the theme-application effect so mount doesn't redundantly re-inject the already-applied theme

## Miscellaneous

- Add `gap: var(--ds-size-300)` on `.header-bar` to give the search and theme switcher consistent spacing
- Remove dead/commented-out SCSS in `App.scss` (legacy `@alaskaairux/design-tokens` import, dead breakpoint blocks, stale margin notes)

**As it appears on DocSite:**

<img width="1170" height="112" alt="Screenshot 2026-06-16 at 12 08 21 PM" src="https://github.com/user-attachments/assets/88d42b9c-6cf0-4d80-ac6a-2794d61dce51" />

**With fixes applied:**

<img width="1037" height="690" alt="Screenshot 2026-06-16 at 3 25 05 PM" src="https://github.com/user-attachments/assets/51ed520c-fb46-4ef1-bdb5-1d54915f9421" />

<img width="1042" height="697" alt="Screenshot 2026-06-16 at 3 25 13 PM" src="https://github.com/user-attachments/assets/7230059a-e28a-4f8c-a4e3-88644432c2b3" />

<img width="1043" height="697" alt="Screenshot 2026-06-16 at 3 25 22 PM" src="https://github.com/user-attachments/assets/32f0cb15-6d3b-452f-be38-6e4d8b9f0b02" />

## Summary by Sourcery

Ensure the header search input consistently displays its placeholder, has correct border styling, presents a balanced submit affordance, and properly tears down its DOM listeners. Split the monolithic `Header` into focused `SiteSearch` and `ThemeSwitcher` components, move GCSE script loading on-demand into React, and harden the icon swap with a CSS safety net.

Bug Fixes:
- Prevent the Google Custom Search input from losing its placeholder text when it is re-rendered asynchronously.
- Fix the search input border styling so the right side is no longer visually cut off.
- Fix `.siteHeader` z-index so the GCS results popup renders above `.sidenav` instead of behind it.
- Remove the theme-switcher `input` event listener on unmount to avoid leaked / duplicate handlers if the `Header` remounts.
- Prevent duplicate GCSE script injection on remount / HMR.
- Preserve theme state across remount by detecting the active theme from the already-injected token stylesheet instead of resetting to `alaska`.

Enhancements:
- Square the search submit button and widen the search input at the `md` breakpoint for a more balanced layout.
- Replace the redundant magnifier inside the submit button with the Auro design system `arrow-right` icon so the button reads as a submit affordance rather than duplicating the magnifier already shown inside the input. The original GCS icon is hidden via CSS to avoid a flash before the swap runs, and a `gcs-svg-fallback` keyframe re-reveals it as a safety net if the swap fails.
- Wait for `auro-icon` to be registered (`customElements.whenDefined`) before committing the swap so we never replace GCS's SVG with an unregistered custom element.
- Restore an `aria-label="Search"` on the swapped button since `auro-icon` is decorative.
- Nullify GCS's empty `.gsc-clear-button` cell so the `.header-bar` `gap` is the single source of truth for input↔button spacing.
- Scope all GCS CSS overrides under `#gcse-search-host` so they don't leak to other CSE widgets.
- Isolate the button icon swap behind a dedicated `searchIconSwap` helper so it can be reverted in a single step if Google CSE markup changes.
- Add `cursor: pointer` on the submit button hover state for a clearer affordance.

Refactors:
- Split the monolithic `Header` class component into `Header` (shell), `SiteSearch`, and `ThemeSwitcher` functional components for clearer effect/cleanup boundaries.
- Move the GCSE `<script>` and host `<div>` out of `index.html` and into `SiteSearch` so React owns load timing via `parsetags: 'explicit'` and explicit `cse.element.render`.
- Remove dead/commented-out SCSS from `App.scss`.
