### PR TITLE
Header & mobile nav tweaks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -508,16 +508,16 @@ const client = new ApolloClient({
 function App() {
   return (
     <ApolloProvider client={client}>
-      <main className="main-wrapper body-default">
-        <Header />
-        <div className="wrapper">
-          <input id="menuCheckbox" type="checkbox" className="menuCheckbox util_displayHiddenVisually"></input>
-          <label htmlFor="menuCheckbox" className="menuCheckbox--label">
-            <img className="menuIcon" src="https://img.icons8.com/material/24/000000/menu--v1.png" alt="icon"></img>
-            <img className="closeIcon" width="24" src="https://img.icons8.com/material/26/000000/multiply--v1.png" alt="icon"></img>
-          </label>
+      <Router>
+        <main className="main-wrapper body-default">
+          <Header />
+          <div className="wrapper">
+            <input id="menuCheckbox" type="checkbox" className="menuCheckbox util_displayHiddenVisually"></input>
+            <label htmlFor="menuCheckbox" className="menuCheckbox--label">
+              <img className="menuIcon" src="https://img.icons8.com/material/24/000000/menu--v1.png" alt="icon"></img>
+              <img className="closeIcon" width="24" src="https://img.icons8.com/material/26/000000/multiply--v1.png" alt="icon"></img>
+            </label>
 
-          <Router>
             <ScrollToTop />
             <SideNav />
             <Routes>
@@ -992,9 +992,9 @@ function App() {
               <Route path="*" element={<NotFound />} />
 
             </Routes>
-          </Router>
-        </div>
-      </main>
+          </div>
+        </main>
+      </Router>
     </ApolloProvider>
   )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -512,7 +512,7 @@ function App() {
         <main className="main-wrapper body-default">
           <Header />
           <div className="wrapper">
-            <input id="menuCheckbox" type="checkbox" className="menuCheckbox util_displayHiddenVisually"></input>
+            <input id="menuCheckbox" type="checkbox" className="menuCheckbox auro_util_displayHiddenVisually"></input>
             <label htmlFor="menuCheckbox" className="menuCheckbox--label">
               <img className="menuIcon" src="https://img.icons8.com/material/24/000000/menu--v1.png" alt="icon"></img>
               <img className="closeIcon" width="24" src="https://img.icons8.com/material/26/000000/multiply--v1.png" alt="icon"></img>

--- a/src/App.js
+++ b/src/App.js
@@ -514,8 +514,8 @@ function App() {
           <div className="wrapper">
             <input id="menuCheckbox" type="checkbox" className="menuCheckbox auro_util_displayHiddenVisually"></input>
             <label htmlFor="menuCheckbox" className="menuCheckbox--label">
-              <img className="menuIcon" src="https://img.icons8.com/material/24/000000/menu--v1.png" alt="icon"></img>
-              <img className="closeIcon" width="24" src="https://img.icons8.com/material/26/000000/multiply--v1.png" alt="icon"></img>
+              <img className="menuIcon" src="https://img.icons8.com/material/24/000000/menu--v1.png" alt="Open menu"></img>
+              <img className="closeIcon" width="24" src="https://img.icons8.com/material/26/000000/multiply--v1.png" alt="Close menu"></img>
             </label>
 
             <ScrollToTop />

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import './style.scss';
 import SiteSearch from './SiteSearch';
@@ -6,22 +6,37 @@ import ThemeSwitcher from './ThemeSwitcher';
 
 function Header() {
   const navigate = useNavigate();
+  const lockupRef = useRef(null);
 
   // auro-lockup renders an internal <a href="/"> inside shadow DOM, which
-  // triggers a full page reload (and resets the theme switcher). Intercept
-  // the bubbled click and route via React Router instead. Modified clicks
-  // (cmd/ctrl/shift/middle-click) fall through so "open in new tab" still
-  // works.
-  const onLockupClick = (e) => {
-    if (e.defaultPrevented) return;
-    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-    e.preventDefault();
-    navigate('/');
-  };
+  // triggers a full page reload (and resets the theme switcher). Click events
+  // are composed: true and bubble out of the shadow root, so we listen on the
+  // host element and preventDefault() to cancel the anchor's navigation, then
+  // route via React Router instead. Modified clicks (cmd/ctrl/shift/middle)
+  // fall through so "open in new tab" still works.
+  //
+  // Using a native addEventListener via ref (rather than React's onClick prop)
+  // avoids any synthetic-event retargeting quirks with web components, and
+  // listening on the host (rather than reaching into the shadow root) keeps us
+  // off Auro's internal DOM structure.
+  useEffect(() => {
+    const host = lockupRef.current;
+    if (!host) return undefined;
+
+    const onClick = (e) => {
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+      e.preventDefault();
+      navigate('/');
+    };
+
+    host.addEventListener('click', onClick);
+    return () => host.removeEventListener('click', onClick);
+  }, [navigate]);
 
   return (
     <header className="siteHeader">
-      <auro-lockup onClick={onLockupClick}>
+      <auro-lockup ref={lockupRef}>
         <span slot="title">Auro</span>
         <span slot="subtitle">design system</span>
       </auro-lockup>

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -1,12 +1,27 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import './style.scss';
 import SiteSearch from './SiteSearch';
 import ThemeSwitcher from './ThemeSwitcher';
 
 function Header() {
+  const navigate = useNavigate();
+
+  // auro-lockup renders an internal <a href="/"> inside shadow DOM, which
+  // triggers a full page reload (and resets the theme switcher). Intercept
+  // the bubbled click and route via React Router instead. Modified clicks
+  // (cmd/ctrl/shift/middle-click) fall through so "open in new tab" still
+  // works.
+  const onLockupClick = (e) => {
+    if (e.defaultPrevented) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+    e.preventDefault();
+    navigate('/');
+  };
+
   return (
     <header className="siteHeader">
-      <auro-lockup>
+      <auro-lockup onClick={onLockupClick}>
         <span slot="title">Auro</span>
         <span slot="subtitle">design system</span>
       </auro-lockup>

--- a/src/components/side-nav.js
+++ b/src/components/side-nav.js
@@ -125,22 +125,16 @@ export default function SideNav(props) {
               {/* TODO: Toggle HIDDEN attr on click to hide/show nav items within a block */}
               <div className="navBlock">
                 {navBlock.items.map((link) => (
-                  <NavLink key={link.route} to={link.route} 
-
+                  <NavLink key={link.route} to={link.route}
+                    onClick={() => {
+                      siteNav.forEach(navBlock => navBlock.items.forEach(link => link.active = false));
+                      link.active = true;
+                      setNav([...siteNav]);
+                      const menuCheckbox = document.getElementById('menuCheckbox');
+                      if (menuCheckbox) menuCheckbox.checked = false;
+                    }}
                     className={`hyperlink hyperlink--nav ${link.active ? 'hyperlink--active': ''} ${link.subNav ? 'hyperlink--subNav': ''} ${link.parent ? 'hyperlink--parent': ''}`}>
-
-                    {/* onClick event that sets nav item state to isActive */}
-                    <span
-                      onClick={() => {
-                        siteNav.forEach(navBlock => navBlock.items.forEach(link => link.active = false));
-                        link.active = true;
-                        setNav([...siteNav]);
-                        const menuCheckbox = document.getElementById('menuCheckbox');
-                        if (menuCheckbox) menuCheckbox.checked = false;
-                      }}>
-
-                      {link.linkTitle}
-                    </span>
+                    <span>{link.linkTitle}</span>
                   </NavLink>
                 ))}
               </div>

--- a/src/components/side-nav.js
+++ b/src/components/side-nav.js
@@ -135,6 +135,8 @@ export default function SideNav(props) {
                         siteNav.forEach(navBlock => navBlock.items.forEach(link => link.active = false));
                         link.active = true;
                         setNav([...siteNav]);
+                        const menuCheckbox = document.getElementById('menuCheckbox');
+                        if (menuCheckbox) menuCheckbox.checked = false;
                       }}>
 
                       {link.linkTitle}

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -337,31 +337,31 @@ auro-swatch-list {
   margin-top: 0;
 }
 
-.menuCheckbox,
-.menuCheckbox--label {
-  position: fixed;
-  bottom: 50px;
-  right: 30px;
-  z-index: 299;
-
+.menuCheckbox {
   @include auro_breakpoint($min: $ds-grid-breakpoint-sm) {
     display: none;
   }
 }
 
 .menuCheckbox--label {
-  &::before {
-    display: block;
-    position: absolute;
-    content: '';
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    background-color: var(--ds-color-background-lighter);
-    box-shadow: 0px 0px 10px #222;
-    right: -12px;
-    top: -13px;
-    z-index: -1;
+  position: fixed;
+  // Stack above <auro-backtotop>, which is fixed at
+  // right/bottom: var(--ds-size-300) (24px) and is ~52px tall on mobile.
+  // 100px bottom clears it; right matches its offset.
+  bottom: 100px;
+  right: var(--ds-size-300);
+  z-index: 299;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: var(--ds-color-background-lighter);
+  box-shadow: 0px 0px 10px #222;
+
+  @include auro_breakpoint($min: $ds-grid-breakpoint-sm) {
+    display: none;
   }
 }
 


### PR DESCRIPTION
# Header & mobile nav tweaks

## Summary

- **Stop the header lockup from triggering a full page reload.** `<auro-lockup>` renders an internal `<a href="/">` that resets the theme switcher and other client state when clicked.
  - Lifted `<Router>` above `<Header>` and intercept the bubbled click to route via `useNavigate('/')`; modified clicks (cmd/ctrl/shift/middle) fall through so "open in new tab" still works.
  - Listener is attached via `ref` + native `addEventListener` on the host (not React's `onClick` prop) to sidestep synthetic-event quirks with web components, while staying off Auro's shadow DOM internals.
  - ADO ticket: [1579141](https://dev.azure.com/itsals/Auro%20Design%20System/_workitems/edit/1579141)
- **Close the mobile nav when a link is selected.** Selecting a nav item now also unchecks `#menuCheckbox`, so the sidenav collapses on navigate instead of staying open over the new page. Handler moved up to the `<NavLink>` itself so keyboard Enter activation closes the menu too, not just mouse clicks.
- **Stop the mobile menu button from overlapping `<auro-backtotop>`.** Repositioned the menu button to stack above the back-to-top button, right-aligned to `var(--ds-size-300)` to match. Also fixed the visually-hidden native checkbox leaking through (the JSX was using the unprefixed utility class name; project sets `$prefix: true`), and gave the menu/close icons meaningful alt text ("Open menu" / "Close menu") so screen readers don't just announce "icon". (Approved by @forrest-for-real)

**Before:**
<img width="412" height="1082" alt="Screenshot 2026-06-17 at 10 35 55 AM" src="https://github.com/user-attachments/assets/9856cf8e-e212-43af-8d6c-9edba8c2c7c6" />

**After:**
<img width="411" height="1059" alt="Screenshot 2026-06-17 at 10 35 35 AM" src="https://github.com/user-attachments/assets/01fbb0b0-7bf6-4150-b58e-7a55612e5597" />

## Test plan

- [x] Header logo: clicking it does nothing (no reload, theme persists).
- [x] Mobile: tapping or keyboard-activating a nav link navigates AND closes the sidenav.
- [x] Mobile, scrolled: menu button and back-to-top button are stacked, right-aligned, and don't overlap.
- [x] No stray native checkbox visible anywhere.
- [x] Screen reader announces "Open menu" / "Close menu" on the hamburger control.