### PR TITLE
feat(docs): add llms.txt for AI tool discoverability

### DIFF
--- a/docs/post-mortem/1592461.md
+++ b/docs/post-mortem/1592461.md
@@ -1,0 +1,37 @@
+# AB#1592461 — `llms.txt` for AI-Tool Discoverability Postmortem
+
+**Branch:** `feat/llms-txt` → `master`
+**PR:** [#455](https://github.com/AlaskaAirlines/AuroDocsSite/pull/455)
+**Scope:** A single static file, `public/llms.txt`, served at `auro.alaskaair.com/llms.txt`, following the [llms.txt convention](https://llmstxt.org/). No build changes (Vite serves `public/` as-is). 4 commits. Part of the Auro AI-readiness initiative.
+
+## Symptoms → Lesson
+
+| If you see... | This doc says... |
+|---|---|
+| `llms.txt` documents design-token prefixes/examples that don't match real tokens | The token names were hand-authored and drifted from `AuroDesignTokens`. Verify token names against the published tokens, not memory. Fixed in `357310fb`. |
+| A component's `label` documented as an attribute where it's actually a slot | Hand-written API notes drift from source. Check the component `src/` JSDoc (`@slot`/`@csspart`) before documenting. Fixed in `357310fb`. |
+| The component list is missing real components or lists ones that don't exist | The hand-maintained list drifted from the published component set. Reconcile against the real inventory. Fixed in `b5890a1f` and `ce8b6eb` (added `auro-slideshow`, `auro-tabs`). |
+| You're maintaining `llms.txt` by hand at all | It's a hand-maintained artifact that *will* keep drifting. The durable fix is to generate it from the aggregate CEM (AB#1593488), not to keep hand-editing it. |
+
+## 1. What shipped
+
+A concise, LLM-optimized index of Auro — what it is, the component list with npm packages and element tags, common usage patterns, a token overview, and doc links. Many AI tools (Perplexity, Cursor, Claude-with-web) automatically check `/llms.txt` when indexing a site, so this makes Auro **passively discoverable** to AI with zero integration work from consuming teams.
+
+## 2. What the review caught — a hand-maintained artifact shipped factual drift
+
+The pre-PR review pass turned up several factual errors in the first cut (`fe0d48c7`), all of the same species: the file was authored by hand and its details had drifted from source.
+
+- **Wrong design-token prefixes** and example code that wouldn't compile as written — corrected against `AuroDesignTokens` (`357310fb`).
+- **`label` described as an attribute** on a component where it's actually a slot — corrected against the component source (`357310fb`).
+- **Component list inaccuracies** — missing/extra entries relative to the real published set (`b5890a1f`), plus two later additions (`auro-slideshow`, `auro-tabs`) once the set was reconciled (`ce8b6eb`).
+
+None were logic bugs — they were accuracy bugs in a document meant to be an *authoritative* reference for AI tools, which makes them exactly the errors that matter most here.
+
+## 3. Root lesson — don't hand-maintain what you can generate
+
+`llms.txt`, the `auro context` doc, and the CEM component list are three hand-maintained views of the same underlying truth (the component set + each component's API). Kept by hand, they drift independently and ship identical-but-inconsistent errors. The intended end state is to **generate `llms.txt` (and the context doc) from the aggregate CEM** so they're derived from one source and can't drift (AB#1593488; publish the aggregate CEM at a stable URL is AB#1593787).
+
+## 4. Follow-ups
+
+- Generate `llms.txt` from the aggregate CEM (AB#1593488) — retire the hand-maintained copy.
+- Reconcile the component lists across `llms.txt`, `auro context`, and the CEM as a stopgap until generation lands.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -76,14 +76,13 @@ All components use the `<auro-*>` custom element tag. Props are set as HTML attr
 | Icon | `@aurodesignsystem/auro-icon` | `<auro-icon>` | Alaska Airlines icon library wrapper |
 | Loader | `@aurodesignsystem/auro-loader` | `<auro-loader>` | Loading spinner |
 | Lockup | `@aurodesignsystem/auro-lockup` | `<auro-lockup>` | Image + text layout lockup |
-| Nav | `@aurodesignsystem/auro-nav` | `<auro-nav>` | Breadcrumb / secondary navigation |
+| Nav | `@aurodesignsystem/auro-nav` | `<auro-nav>` | Breadcrumb navigation |
 | Pane | `@aurodesignsystem/auro-pane` | `<auro-pane>` | Selectable pricing or option pane |
 | Popover | `@aurodesignsystem/auro-popover` | `<auro-popover>` | Tooltip-style popover overlay |
 | Side Nav | `@aurodesignsystem/auro-sidenav` | `<auro-sidenav>` | Vertical side navigation |
 | Skeleton | `@aurodesignsystem/auro-skeleton` | `<auro-skeleton>` | Loading placeholder skeleton |
-| Slideshow | `@aurodesignsystem/auro-slideshow` | `<auro-slideshow>` | Image/content slideshow |
 | Table | `@aurodesignsystem/auro-table` | `<auro-table>` | Accessible data table |
-| Tabs | `@aurodesignsystem/auro-tabs` | `<auro-tabs>` | Tabbed content panels |
+| Tail | `@aurodesignsystem/auro-tail` | `<auro-tail>` | Alaska, Hawaiian, and partner airline tail graphics |
 | Toast | `@aurodesignsystem/auro-toast` | `<auro-toast>` | Transient notification toast |
 | Token List | `@aurodesignsystem/auro-tokenlist` | `<auro-tokenlist>` | Design token display utilities |
 
@@ -97,7 +96,7 @@ All components use the `<auro-*>` custom element tag. Props are set as HTML attr
 ### Alert message
 ```html
 <auro-alert type="success">Your changes have been saved.</auro-alert>
-<!-- types: error | warning | success | information -->
+<!-- types: information | error | success | warning -->
 ```
 
 ### Form input (from auro-formkit)
@@ -122,7 +121,7 @@ All components use the `<auro-*>` custom element tag. Props are set as HTML attr
   <span slot="header">Dialog Title</span>
   <div slot="content">Dialog body content</div>
 </auro-dialog>
-<auro-button onclick="document.querySelector('#myDialog').setAttribute('open', true)">Open</auro-button>
+<auro-button onclick="document.querySelector('#myDialog').show()">Open</auro-button>
 ```
 
 ## Accessibility
@@ -149,7 +148,7 @@ Auro supports multiple visual themes via CSS custom property overrides. Set on t
 | CLI | `@aurodesignsystem/auro-cli` | Component builds, docs generation, migrations |
 | Design Tokens | `@aurodesignsystem/design-tokens` | CSS custom properties for color, spacing, type |
 | Icons | `@alaskaairux/icons` | Alaska Airlines SVG icon library |
-| Web Core Style Sheets | `@aurodesignsystem/WebCoreStyleSheets` | Base CSS reset and utility classes |
+| Web Core Style Sheets | `@aurodesignsystem/webcorestylesheets` | Base CSS reset and utility classes |
 
 ## Key Documentation Pages
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -45,7 +45,7 @@ npm install @aurodesignsystem/design-tokens
 @import "@aurodesignsystem/design-tokens/dist/themes/CSSCustomProperties--bundled.css";
 ```
 
-Token naming convention: `--ds-color-*`, `--ds-size-*`, `--ds-font-*`, `--ds-border-*`
+Token naming convention: `--ds-basic-*` and `--ds-advanced-*` (e.g. `--ds-advanced-color-*`, `--ds-basic-color-*`)
 
 Token reference: https://auro.alaskaair.com/getting-started/developers/token-usage
 
@@ -76,8 +76,8 @@ All components use the `<auro-*>` custom element tag. Props are set as HTML attr
 | Icon | `@aurodesignsystem/auro-icon` | `<auro-icon>` | Alaska Airlines icon library wrapper |
 | Loader | `@aurodesignsystem/auro-loader` | `<auro-loader>` | Loading spinner |
 | Lockup | `@aurodesignsystem/auro-lockup` | `<auro-lockup>` | Image + text layout lockup |
-| Nav | `@aurodesignsystem/auro-nav` | `<auro-nav>` | Breadcrumb navigation |
-| Pane | `@aurodesignsystem/auro-pane` | `<auro-pane>` | Selectable pricing or option pane |
+| Nav | `@aurodesignsystem/auro-nav` | `<auro-nav>` | Secondary navigation aid (relation to higher-level pages) |
+| Pane | `@aurodesignsystem/auro-pane` | `<auro-pane>` | Selectable shoulder dates with associated prices |
 | Popover | `@aurodesignsystem/auro-popover` | `<auro-popover>` | Tooltip-style popover overlay |
 | Side Nav | `@aurodesignsystem/auro-sidenav` | `<auro-sidenav>` | Vertical side navigation |
 | Skeleton | `@aurodesignsystem/auro-skeleton` | `<auro-skeleton>` | Loading placeholder skeleton |
@@ -100,8 +100,11 @@ All components use the `<auro-*>` custom element tag. Props are set as HTML attr
 ```
 
 ### Form input (from auro-formkit)
+The field label is a slot, not an attribute. Import via subpath (auro-formkit has no root export).
 ```html
-<auro-input label="Email" type="email" required></auro-input>
+<auro-input type="email" required>
+  <span slot="label">Email</span>
+</auro-input>
 ```
 
 ### Icon usage
@@ -137,7 +140,7 @@ Auro supports multiple visual themes via CSS custom property overrides. Set on t
 
 ```css
 :root {
-  --ds-color-brand-base-100: #01426a; /* Alaska blue */
+  --ds-advanced-color-button-primary-background: #01426a; /* Alaska blue */
 }
 ```
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -81,7 +81,9 @@ All components use the `<auro-*>` custom element tag. Props are set as HTML attr
 | Popover | `@aurodesignsystem/auro-popover` | `<auro-popover>` | Tooltip-style popover overlay |
 | Side Nav | `@aurodesignsystem/auro-sidenav` | `<auro-sidenav>` | Vertical side navigation |
 | Skeleton | `@aurodesignsystem/auro-skeleton` | `<auro-skeleton>` | Loading placeholder skeleton |
+| Slideshow | `@aurodesignsystem/auro-slideshow` | `<auro-slideshow>` | Image/content slideshow |
 | Table | `@aurodesignsystem/auro-table` | `<auro-table>` | Accessible data table |
+| Tabs | `@aurodesignsystem/auro-tabs` | `<auro-tabs>` | Tabbed content panels |
 | Tail | `@aurodesignsystem/auro-tail` | `<auro-tail>` | Alaska, Hawaiian, and partner airline tail graphics |
 | Toast | `@aurodesignsystem/auro-toast` | `<auro-toast>` | Transient notification toast |
 | Token List | `@aurodesignsystem/auro-tokenlist` | `<auro-tokenlist>` | Design token display utilities |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,160 @@
+# Auro Design System
+
+> Auro is Alaska Airlines' open-source design system built on web components (custom elements). It provides accessible, themeable UI components, design tokens, and tooling for building Alaska Airlines digital products across web frameworks.
+
+## Overview
+
+- **Technology:** Web Components (Custom Elements v1), built with Lit
+- **Frameworks:** Framework-agnostic; works with React, Vue, Angular, Svelte, or plain HTML
+- **npm scope:** `@aurodesignsystem/` (primary), `@alaskaairux/` (legacy)
+- **Docs site:** https://auro.alaskaair.com
+- **GitHub org:** https://github.com/AlaskaAirlines
+- **License:** Apache-2.0
+
+## Installing Components
+
+Each component is a separate npm package. Install individually:
+
+```bash
+npm install @aurodesignsystem/auro-button
+```
+
+Register the custom element before use:
+
+```js
+import "@aurodesignsystem/auro-button";
+// element is now available as <auro-button> in HTML
+```
+
+All components support CDN usage via unpkg:
+
+```html
+<script type="module" src="https://unpkg.com/@aurodesignsystem/auro-button/dist/registered.js"></script>
+```
+
+## Design Tokens
+
+Design tokens are in `@aurodesignsystem/design-tokens`. They are distributed as CSS custom properties.
+
+```bash
+npm install @aurodesignsystem/design-tokens
+```
+
+```css
+/* Import all themes */
+@import "@aurodesignsystem/design-tokens/dist/themes/CSSCustomProperties--bundled.css";
+```
+
+Token naming convention: `--ds-color-*`, `--ds-size-*`, `--ds-font-*`, `--ds-border-*`
+
+Token reference: https://auro.alaskaair.com/getting-started/developers/token-usage
+
+## Component Library
+
+All components use the `<auro-*>` custom element tag. Props are set as HTML attributes or JavaScript properties.
+
+| Component | Package | Element Tag | Description |
+|---|---|---|---|
+| Accordion | `@aurodesignsystem/auro-accordion` | `<auro-accordion>` | Expandable content sections |
+| Alert | `@aurodesignsystem/auro-alert` | `<auro-alert>` | Inline status messages (info, success, warning, error) |
+| Avatar | `@aurodesignsystem/auro-avatar` | `<auro-avatar>` | User or entity avatar display |
+| Background | `@aurodesignsystem/auro-background` | `<auro-background>` | Themed background wrapper |
+| Back to Top | `@aurodesignsystem/auro-backtotop` | `<auro-backtotop>` | Scroll-to-top button |
+| Badge | `@aurodesignsystem/auro-badge` | `<auro-badge>` | Status or count badge |
+| Banner | `@aurodesignsystem/auro-banner` | `<auro-banner>` | Full-width promotional banner |
+| Button | `@aurodesignsystem/auro-button` | `<auro-button>` | Primary interactive button with loading state |
+| Card | `@aurodesignsystem/auro-card` | `<auro-card>` | Content card container |
+| Carousel | `@aurodesignsystem/auro-carousel` | `<auro-carousel>` | Horizontally scrollable content carousel |
+| Date/Time | `@aurodesignsystem/auro-datetime` | `<auro-datetime>` | Localized date and time formatting |
+| Dialog | `@aurodesignsystem/auro-dialog` | `<auro-dialog>` | Modal dialog overlay |
+| Drawer | `@aurodesignsystem/auro-drawer` | `<auro-drawer>` | Slide-in panel from screen edge |
+| Flight | `@aurodesignsystem/auro-flight` | `<auro-flight>` | Flight segment display (origin, destination, stops) |
+| Flightline | `@aurodesignsystem/auro-flightline` | `<auro-flightline>` | Visual flight path/stop indicator |
+| Form Kit | `@aurodesignsystem/auro-formkit` | `<auro-input>`, `<auro-select>`, `<auro-datepicker>`, `<auro-combobox>`, `<auro-checkbox>`, `<auro-radio>` | Full form component suite |
+| Header | `@aurodesignsystem/auro-header` | `<auro-header>` | Page/section heading with hierarchy |
+| Hyperlink | `@aurodesignsystem/auro-hyperlink` | `<auro-hyperlink>` | Accessible anchor link |
+| Icon | `@aurodesignsystem/auro-icon` | `<auro-icon>` | Alaska Airlines icon library wrapper |
+| Loader | `@aurodesignsystem/auro-loader` | `<auro-loader>` | Loading spinner |
+| Lockup | `@aurodesignsystem/auro-lockup` | `<auro-lockup>` | Image + text layout lockup |
+| Nav | `@aurodesignsystem/auro-nav` | `<auro-nav>` | Breadcrumb / secondary navigation |
+| Pane | `@aurodesignsystem/auro-pane` | `<auro-pane>` | Selectable pricing or option pane |
+| Popover | `@aurodesignsystem/auro-popover` | `<auro-popover>` | Tooltip-style popover overlay |
+| Side Nav | `@aurodesignsystem/auro-sidenav` | `<auro-sidenav>` | Vertical side navigation |
+| Skeleton | `@aurodesignsystem/auro-skeleton` | `<auro-skeleton>` | Loading placeholder skeleton |
+| Slideshow | `@aurodesignsystem/auro-slideshow` | `<auro-slideshow>` | Image/content slideshow |
+| Table | `@aurodesignsystem/auro-table` | `<auro-table>` | Accessible data table |
+| Tabs | `@aurodesignsystem/auro-tabs` | `<auro-tabs>` | Tabbed content panels |
+| Toast | `@aurodesignsystem/auro-toast` | `<auro-toast>` | Transient notification toast |
+| Token List | `@aurodesignsystem/auro-tokenlist` | `<auro-tokenlist>` | Design token display utilities |
+
+## Common Patterns
+
+### Button with loading state
+```html
+<auro-button loading>Save</auro-button>
+```
+
+### Alert message
+```html
+<auro-alert type="success">Your changes have been saved.</auro-alert>
+<!-- types: error | warning | success | information -->
+```
+
+### Form input (from auro-formkit)
+```html
+<auro-input label="Email" type="email" required></auro-input>
+```
+
+### Icon usage
+```html
+<auro-icon category="interface" name="arrow-right"></auro-icon>
+```
+
+### Hyperlink
+```html
+<auro-hyperlink href="/flights">View flights</auro-hyperlink>
+<auro-hyperlink href="https://example.com" target="_blank">External link</auro-hyperlink>
+```
+
+### Dialog (modal)
+```html
+<auro-dialog id="myDialog">
+  <span slot="header">Dialog Title</span>
+  <div slot="content">Dialog body content</div>
+</auro-dialog>
+<auro-button onclick="document.querySelector('#myDialog').setAttribute('open', true)">Open</auro-button>
+```
+
+## Accessibility
+
+All Auro components are built to WCAG 2.1 AA standards. Key notes:
+- Use the `ariaLabel` slot on `<auro-button>` for icon-only buttons
+- `<auro-hyperlink>` handles rel="noopener noreferrer" automatically for external links
+- All form components in auro-formkit include built-in error state and aria-invalid handling
+
+## Theming
+
+Auro supports multiple visual themes via CSS custom property overrides. Set on the `:root` or a scoped container:
+
+```css
+:root {
+  --ds-color-brand-base-100: #01426a; /* Alaska blue */
+}
+```
+
+## Tooling
+
+| Tool | Package | Purpose |
+|---|---|---|
+| CLI | `@aurodesignsystem/auro-cli` | Component builds, docs generation, migrations |
+| Design Tokens | `@aurodesignsystem/design-tokens` | CSS custom properties for color, spacing, type |
+| Icons | `@alaskaairux/icons` | Alaska Airlines SVG icon library |
+| Web Core Style Sheets | `@aurodesignsystem/WebCoreStyleSheets` | Base CSS reset and utility classes |
+
+## Key Documentation Pages
+
+- Getting started: https://auro.alaskaair.com/getting-started/developers/overview
+- Component status: https://auro.alaskaair.com/component-status
+- Design tokens: https://auro.alaskaair.com/getting-started/developers/token-usage
+- Contributing: https://auro.alaskaair.com/getting-started/developers/contributing
+- Browser support: https://auro.alaskaair.com/support/browsersSupport


### PR DESCRIPTION
Related ADO story: AB#1592461

Adds a \`public/llms.txt\` following the llms.txt specification (https://llmstxt.org/), which helps AI tools (Claude, Cursor, Perplexity, Copilot) understand what a site contains.

## Summary by Sourcery

Documentation:
- Introduce a public llms.txt file to improve discoverability and understanding of site content by AI tools and LLM-based crawlers.